### PR TITLE
Enable GitHub Pages in deploy workflow configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
Updated the GitHub Pages deployment workflow to explicitly enable the Pages configuration step.

## Key Changes
- Added `enablement: true` configuration to the `configure-pages` action in the deploy workflow
- This ensures GitHub Pages is properly enabled during the deployment process

## Implementation Details
The `configure-pages@v5` action now includes explicit enablement configuration, which guarantees that GitHub Pages functionality is activated as part of the CI/CD pipeline before the artifact upload step.

https://claude.ai/code/session_01B7ya5yRyAiH39qAesqGTHE