### PR TITLE
feat: AI word translation, phrase tokenizer, 30 Scrum Open questions

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -850,3 +850,42 @@ progress::-webkit-progress-value {
   color: var(--text-secondary);
   margin-bottom: 0.5rem;
 }
+
+/* Any-word clickable spans (AI-translatable) */
+.any-word {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: #b0bec5;
+  text-underline-offset: 3px;
+  cursor: pointer;
+  border-radius: 2px;
+  transition: background 0.15s;
+}
+
+.any-word:hover {
+  background: #eceff1;
+}
+
+/* Inline loading indicator while AI translates */
+.translate-loading {
+  color: var(--primary);
+  font-style: italic;
+}
+
+/* Note field inside a TermSense */
+.sense-note {
+  font-size: 0.82rem;
+  font-style: italic;
+  color: var(--text-secondary);
+  margin-top: 0.25rem;
+  padding: 0.2rem 0.4rem;
+  background: var(--bg);
+  border-radius: 4px;
+}
+
+/* AI-translated tag badge */
+.tag-ai {
+  background: #e8eaf6;
+  color: #3949ab;
+  border-color: #c5cae9;
+}

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,0 +1,48 @@
+import { supabase } from './supabase';
+
+export interface TranslateResult {
+  en: string;
+  vi: string;
+  note: string;
+}
+
+const SYSTEM_PROMPT = `You are a Vietnamese-English expert specializing in Scrum and Agile terminology.
+Given a word or phrase (typically from a Scrum context), respond with JSON only — no markdown fences:
+{"en": "<concise English definition, 1-2 sentences>", "vi": "<Vietnamese translation/explanation, 1-2 sentences>", "note": "<optional usage tip in Vietnamese, or empty string>"}`;
+
+export async function translateTerm(word: string): Promise<TranslateResult> {
+  try {
+    return await callModel('google/gemini-2.0-flash-exp:free', word);
+  } catch {
+    // Rate-limit or error on free model — fall back to cheap paid model
+    return await callModel('google/gemini-flash-1.5-8b', word);
+  }
+}
+
+async function callModel(model: string, word: string): Promise<TranslateResult> {
+  const { data, error } = await supabase.functions.invoke('openrouter', {
+    body: {
+      model,
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: `Translate: "${word}"` },
+      ],
+      max_tokens: 200,
+    },
+  });
+
+  if (error) throw new Error(error.message);
+  if (data?.error) throw new Error(String(data.error?.message ?? data.error));
+
+  const content: string = data?.choices?.[0]?.message?.content ?? '';
+  try {
+    const parsed = JSON.parse(content.trim());
+    return {
+      en: String(parsed.en ?? word),
+      vi: String(parsed.vi ?? word),
+      note: String(parsed.note ?? ''),
+    };
+  } catch {
+    return { en: word, vi: content.trim().slice(0, 300), note: '' };
+  }
+}

--- a/src/lib/components/TermPopup.svelte
+++ b/src/lib/components/TermPopup.svelte
@@ -80,6 +80,9 @@
             </div>
             <div class="sense-en">{sense.en}</div>
             <div class="sense-vi">{sense.vi}</div>
+            {#if sense.note}
+              <div class="sense-note">{sense.note}</div>
+            {/if}
           </div>
         {/each}
       </div>
@@ -88,7 +91,7 @@
       {#if term.tags.length}
         <div class="tags">
           {#each term.tags as tag}
-            <span class="tag">{tag}</span>
+            <span class="tag {tag === 'ai-dịch' ? 'tag-ai' : ''}">{tag}</span>
           {/each}
         </div>
       {/if}

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -40,6 +40,7 @@ async function syncTerms(): Promise<void> {
       register: s.register,
       en: s.en,
       vi: s.vi,
+      note: s.note ?? undefined,
       sortOrder: s.sort_order ?? 0,
     }))
   );

--- a/src/lib/translate.ts
+++ b/src/lib/translate.ts
@@ -1,0 +1,124 @@
+import { db } from './db';
+import { supabase } from './supabase';
+import { translateTerm } from './ai';
+import type { Term } from './types';
+
+/**
+ * Tokenizes a text stem into clickable HTML spans.
+ *
+ * Strategy — longest-match-first greedy scan:
+ *   1. Check each position against known terms (sorted longest → shortest).
+ *      Multi-word phrases ("Product Owner") are matched before their parts.
+ *   2. Remaining letter sequences become `.any-word` spans (AI-translatable).
+ *   3. Non-letter characters (spaces, punctuation) are emitted as plain text.
+ */
+export function tokenizeStem(stem: string, knownTerms: Term[]): string {
+  const sorted = [...knownTerms].sort((a, b) => b.text.length - a.text.length);
+  const out: string[] = [];
+  let i = 0;
+
+  while (i < stem.length) {
+    let matched = false;
+
+    for (const term of sorted) {
+      const t = term.text;
+      if (i + t.length > stem.length) continue;
+      if (stem.slice(i, i + t.length).toLowerCase() !== t.toLowerCase()) continue;
+      // Require word boundaries so "Sprint" doesn't match inside "Sprinting"
+      const before = i === 0 || !isLetter(stem[i - 1]);
+      const after = i + t.length >= stem.length || !isLetter(stem[i + t.length]);
+      if (before && after) {
+        const raw = stem.slice(i, i + t.length);
+        out.push(
+          `<span class="glossary-term" data-term-id="${term.id}" tabindex="0" role="button">${escHtml(raw)}</span>`
+        );
+        i += t.length;
+        matched = true;
+        break;
+      }
+    }
+
+    if (matched) continue;
+
+    if (isLetter(stem[i])) {
+      let j = i + 1;
+      while (j < stem.length && isLetter(stem[j])) j++;
+      const word = stem.slice(i, j);
+      if (word.length >= 2) {
+        out.push(
+          `<span class="any-word" data-word="${escAttr(word)}" tabindex="0" role="button">${escHtml(word)}</span>`
+        );
+      } else {
+        out.push(escHtml(word));
+      }
+      i = j;
+    } else {
+      out.push(escHtml(stem[i]));
+      i++;
+    }
+  }
+
+  return out.join('');
+}
+
+/**
+ * Returns the term ID for rawText, creating it via AI translation if not cached.
+ * Writes new translations to both Supabase (persistent) and Dexie (local cache).
+ */
+export async function lookupOrTranslate(rawText: string, ownerId: string): Promise<string> {
+  const normalized = rawText.trim();
+
+  const existing = await db.terms
+    .filter((t) => t.text.toLowerCase() === normalized.toLowerCase())
+    .first();
+  if (existing) return existing.id;
+
+  const result = await translateTerm(normalized);
+
+  const termId = crypto.randomUUID();
+  const senseId = crypto.randomUUID();
+  const termType: 'word' | 'phrase' = normalized.includes(' ') ? 'phrase' : 'word';
+
+  await supabase.from('terms').insert({
+    id: termId,
+    text: normalized,
+    type: termType,
+    tags: ['ai-dịch'],
+    owner_id: ownerId,
+  });
+
+  await supabase.from('term_senses').insert({
+    id: senseId,
+    term_id: termId,
+    register: 'general',
+    en: result.en,
+    vi: result.vi,
+    note: result.note || null,
+    sort_order: 0,
+  });
+
+  await db.terms.put({ id: termId, text: normalized, type: termType, tags: ['ai-dịch'], ownerId });
+  await db.termSenses.put({
+    id: senseId,
+    termId,
+    register: 'general',
+    en: result.en,
+    vi: result.vi,
+    note: result.note || undefined,
+    sortOrder: 0,
+  });
+
+  return termId;
+}
+
+function isLetter(ch: string): boolean {
+  return /[a-zA-Z]/.test(ch);
+}
+
+function escHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function escAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,7 @@ export interface TermSense {
   register: 'general' | 'scrum';
   en: string;
   vi: string;
+  note?: string;
   sortOrder: number;
 }
 

--- a/src/routes/quiz/+page.svelte
+++ b/src/routes/quiz/+page.svelte
@@ -4,6 +4,8 @@
   import { progressMap, getProgress, saveProgress } from '$lib/stores/mastery';
   import { improveProgress, canPractice, shuffleByIndex, getBadge } from '$lib/srs';
   import { sessionLookups } from '$lib/stores/session';
+  import { authUser } from '$lib/stores/auth';
+  import { tokenizeStem, lookupOrTranslate } from '$lib/translate';
   import type { Question, QuestionOption, Term } from '$lib/types';
   import TermPopup from '$lib/components/TermPopup.svelte';
 
@@ -29,7 +31,10 @@
   let showHint = false;
   let highlightedStem = '';
   let selectedTermId: string | null = null;
+  let allTermsForTokenize: Term[] = [];
+  let translatingWord: string | null = null;
 
+  $: currentUserId = $authUser?.id;
   $: currentQ = sessionQuestions[sessionIndex] ?? null;
   $: progress = currentQ ? getProgress($progressMap, 'question', currentQ.id) : undefined;
   $: selectedOpt = options.find((o) => o.id === selectedOptionId);
@@ -56,7 +61,10 @@
   $: if (currentQ) loadQuestion(currentQ);
 
   onMount(async () => {
-    allQuestions = await db.questions.toArray();
+    [allQuestions, allTermsForTokenize] = await Promise.all([
+      db.questions.toArray(),
+      db.terms.toArray(),
+    ]);
     initSession();
   });
 
@@ -98,33 +106,33 @@
 
     options = shuffleByIndex(opts.sort((a, b) => a.sortOrder - b.sortOrder), sessionIndex);
     termRefs = refs;
-    highlightedStem = buildHighlightedStem(q.stem, refs);
+    highlightedStem = tokenizeStem(q.stem, allTermsForTokenize);
   }
 
-  // Wraps term matches in the stem with clickable spans.
-  // Uses null-byte placeholders so shorter terms don't re-match inside already-wrapped longer ones.
-  function buildHighlightedStem(stem: string, terms: Term[]): string {
-    const sorted = [...terms].sort((a, b) => b.text.length - a.text.length);
-    const replacements: string[] = [];
-    let result = stem;
-    for (const term of sorted) {
-      const esc = term.text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const rx = new RegExp(`\\b(${esc})\\b`, 'gi');
-      result = result.replace(rx, (match) => {
-        const ph = `\x00${replacements.length}\x00`;
-        replacements.push(
-          `<span class="glossary-term" data-term-id="${term.id}" tabindex="0" role="button">${match}</span>`
-        );
-        return ph;
-      });
-    }
-    return result.replace(/\x00(\d+)\x00/g, (_, i) => replacements[+i]);
-  }
-
-  function handleStemInteraction(e: MouseEvent | KeyboardEvent) {
+  async function handleStemInteraction(e: MouseEvent | KeyboardEvent) {
     if (e instanceof KeyboardEvent && e.key !== 'Enter' && e.key !== ' ') return;
-    const el = (e.target as HTMLElement).closest<HTMLElement>('[data-term-id]');
-    if (el?.dataset.termId) selectedTermId = el.dataset.termId;
+
+    const termEl = (e.target as HTMLElement).closest<HTMLElement>('[data-term-id]');
+    if (termEl?.dataset.termId) {
+      selectedTermId = termEl.dataset.termId;
+      return;
+    }
+
+    if (!currentUserId || translatingWord) return;
+    const wordEl = (e.target as HTMLElement).closest<HTMLElement>('[data-word]');
+    if (!wordEl?.dataset.word) return;
+
+    const word = wordEl.dataset.word;
+    translatingWord = word;
+    try {
+      const termId = await lookupOrTranslate(word, currentUserId);
+      allTermsForTokenize = await db.terms.toArray();
+      selectedTermId = termId;
+    } catch (err) {
+      console.error('Translation failed:', err);
+    } finally {
+      translatingWord = null;
+    }
   }
 
   async function selectOption(opt: QuestionOption) {
@@ -302,11 +310,10 @@
       {@html highlightedStem}
     </div>
 
-    {#if termRefs.length > 0}
-      <p class="glossary-hint-label">
-        💡 Click vào <span class="glossary-term-demo">từ gạch chân</span> để xem nghĩa tiếng Việt
-      </p>
-    {/if}
+    <p class="glossary-hint-label">
+      💡 Click vào <span class="glossary-term-demo">thuật ngữ</span> hoặc bất kỳ từ nào để tra nghĩa
+      {#if translatingWord}<span class="translate-loading">· Đang dịch "{translatingWord}"…</span>{/if}
+    </p>
 
     <!-- Hint toggle (only visible before answering) -->
     {#if currentQ.explanationVi && !answered}

--- a/supabase/functions/openrouter/index.ts
+++ b/supabase/functions/openrouter/index.ts
@@ -56,8 +56,9 @@ serve(async (req: Request) => {
     );
   }
 
-  // Default to a lightweight free model
-  const model = body.model ?? 'meta-llama/llama-3.2-3b-instruct:free';
+  // Default to a capable free multilingual model (good Vietnamese + domain terms).
+  // Swap this single line to try another model, e.g. 'openai/gpt-oss-20b:free'.
+  const model = body.model ?? 'google/gemini-2.0-flash-exp:free';
 
   const response = await fetch(OPENROUTER_URL, {
     method: 'POST',

--- a/supabase/migrations/003_ai_terms.sql
+++ b/supabase/migrations/003_ai_terms.sql
@@ -1,0 +1,2 @@
+-- Add optional note column to term_senses for AI-translated context hints
+ALTER TABLE public.term_senses ADD COLUMN IF NOT EXISTS note text;

--- a/supabase/seed_scrum_open.sql
+++ b/supabase/seed_scrum_open.sql
@@ -1,0 +1,456 @@
+-- Scrum Open Assessment — 30 representative questions (PSM-I)
+-- Replace YOUR_USER_ID with your Supabase user UUID before running.
+-- Run via: psql <connection-string> -f supabase/seed_scrum_open.sql
+--       or paste into Supabase Studio → SQL Editor.
+
+DO $$ DECLARE
+  owner uuid := 'YOUR_USER_ID';
+  q1  uuid; q2  uuid; q3  uuid; q4  uuid; q5  uuid;
+  q6  uuid; q7  uuid; q8  uuid; q9  uuid; q10 uuid;
+  q11 uuid; q12 uuid; q13 uuid; q14 uuid; q15 uuid;
+  q16 uuid; q17 uuid; q18 uuid; q19 uuid; q20 uuid;
+  q21 uuid; q22 uuid; q23 uuid; q24 uuid; q25 uuid;
+  q26 uuid; q27 uuid; q28 uuid; q29 uuid; q30 uuid;
+BEGIN
+  q1  := gen_random_uuid(); q2  := gen_random_uuid(); q3  := gen_random_uuid();
+  q4  := gen_random_uuid(); q5  := gen_random_uuid(); q6  := gen_random_uuid();
+  q7  := gen_random_uuid(); q8  := gen_random_uuid(); q9  := gen_random_uuid();
+  q10 := gen_random_uuid(); q11 := gen_random_uuid(); q12 := gen_random_uuid();
+  q13 := gen_random_uuid(); q14 := gen_random_uuid(); q15 := gen_random_uuid();
+  q16 := gen_random_uuid(); q17 := gen_random_uuid(); q18 := gen_random_uuid();
+  q19 := gen_random_uuid(); q20 := gen_random_uuid(); q21 := gen_random_uuid();
+  q22 := gen_random_uuid(); q23 := gen_random_uuid(); q24 := gen_random_uuid();
+  q25 := gen_random_uuid(); q26 := gen_random_uuid(); q27 := gen_random_uuid();
+  q28 := gen_random_uuid(); q29 := gen_random_uuid(); q30 := gen_random_uuid();
+
+  -- ────────────────────────────────────────────────────────────
+  -- Questions
+  -- ────────────────────────────────────────────────────────────
+  INSERT INTO public.questions
+    (id, exam, stem, explanation_en, explanation_vi, tags, term_refs, owner_id)
+  VALUES
+    -- 1
+    (q1, 'PSM-I',
+     'What is the maximum length of a Sprint?',
+     'The Scrum Guide states Sprints are one month or less. No Sprint may be longer than one month. When a Sprint''s horizon is too long, the Sprint Goal may become invalid and complexity may rise.',
+     'Scrum Guide quy định Sprint có thời gian tối đa là một tháng. Sprint dài hơn có thể khiến Sprint Goal mất giá trị và rủi ro gia tăng.',
+     ARRAY['sprint', 'timebox'], '{}'::uuid[], owner),
+
+    -- 2
+    (q2, 'PSM-I',
+     'Who is accountable for maximizing the value of the product resulting from the work of the Scrum Team?',
+     'The Product Owner is accountable for maximizing the value of the product resulting from the work of the Scrum Team. How this is done may vary widely across organizations, Scrum Teams, and individuals.',
+     'Product Owner chịu trách nhiệm tối đa hóa giá trị của sản phẩm từ công việc của Scrum Team. Cách thực hiện có thể khác nhau tùy tổ chức.',
+     ARRAY['product-owner', 'accountability'], '{}'::uuid[], owner),
+
+    -- 3
+    (q3, 'PSM-I',
+     'What is the timebox for the Daily Scrum?',
+     'The Daily Scrum is a 15-minute event for the Developers of the Scrum Team. To reduce complexity, it is held at the same time and place every working day of the Sprint.',
+     'Daily Scrum là sự kiện 15 phút dành cho Developers. Được tổ chức cùng giờ, cùng địa điểm mỗi ngày làm việc trong Sprint để giảm phức tạp.',
+     ARRAY['daily-scrum', 'timebox'], '{}'::uuid[], owner),
+
+    -- 4
+    (q4, 'PSM-I',
+     'Who has the authority to cancel a Sprint?',
+     'Only the Product Owner has the authority to cancel a Sprint. A Sprint would be cancelled if the Sprint Goal becomes obsolete. This is a rare occurrence.',
+     'Chỉ Product Owner mới có quyền hủy Sprint. Sprint bị hủy khi Sprint Goal trở nên lỗi thời. Đây là trường hợp hiếm gặp.',
+     ARRAY['sprint', 'product-owner', 'cancellation'], '{}'::uuid[], owner),
+
+    -- 5
+    (q5, 'PSM-I',
+     'Which three pillars uphold every implementation of empirical process control?',
+     'The three pillars of empiricism are Transparency, Inspection, and Adaptation. Scrum combines these pillars to make decisions based on what is observed rather than speculation.',
+     'Ba trụ cột của chủ nghĩa kinh nghiệm trong Scrum là Minh bạch (Transparency), Thanh tra (Inspection) và Thích nghi (Adaptation). Đây là nền tảng cho mọi quyết định dựa trên thực tế quan sát được.',
+     ARRAY['empiricism', 'transparency', 'inspection', 'adaptation'], '{}'::uuid[], owner),
+
+    -- 6
+    (q6, 'PSM-I',
+     'Which statement about the Increment is correct?',
+     'Multiple Increments may be created within a Sprint. The sum of the Increments is presented at the Sprint Review, supporting empiricism. The Product Owner may decide to release any Increment before the Sprint ends.',
+     'Nhiều Increment có thể được tạo ra trong một Sprint. Product Owner có thể quyết định phát hành bất kỳ Increment nào trước khi Sprint kết thúc.',
+     ARRAY['increment', 'sprint'], '{}'::uuid[], owner),
+
+    -- 7
+    (q7, 'PSM-I',
+     'What is the maximum timebox for Sprint Planning for a one-month Sprint?',
+     'Sprint Planning is timeboxed to a maximum of 8 hours for a one-month Sprint. For shorter Sprints, the event is usually shorter.',
+     'Sprint Planning được giới hạn tối đa 8 giờ cho Sprint một tháng. Sprint ngắn hơn thường có Sprint Planning ngắn hơn tương ứng.',
+     ARRAY['sprint-planning', 'timebox'], '{}'::uuid[], owner),
+
+    -- 8
+    (q8, 'PSM-I',
+     'What is the commitment for the Sprint Backlog?',
+     'The Sprint Goal is the commitment for the Sprint Backlog. The Sprint Goal is the single objective for the Sprint and provides flexibility to Developers while maintaining focus.',
+     'Sprint Goal là cam kết gắn với Sprint Backlog. Sprint Goal tạo ra sự linh hoạt cho Developers trong khi vẫn duy trì trọng tâm nhất quán.',
+     ARRAY['sprint-backlog', 'sprint-goal', 'commitment'], '{}'::uuid[], owner),
+
+    -- 9
+    (q9, 'PSM-I',
+     'Which of the following best describes the Scrum Master''s role?',
+     'The Scrum Master is accountable for establishing Scrum and coaching the Scrum Team in self-management and cross-functionality. The Scrum Master is a servant leader, not a manager who assigns work.',
+     'Scrum Master chịu trách nhiệm thiết lập Scrum và huấn luyện Scrum Team về tự quản lý và đa chức năng. Scrum Master là người lãnh đạo phục vụ, không phải quản lý phân công công việc.',
+     ARRAY['scrum-master', 'servant-leader'], '{}'::uuid[], owner),
+
+    -- 10
+    (q10, 'PSM-I',
+     'Who are the members of a Scrum Team?',
+     'A Scrum Team consists of one Scrum Master, one Product Owner, and Developers. There are no sub-teams or hierarchies within a Scrum Team; it is a cohesive unit of professionals.',
+     'Scrum Team gồm một Scrum Master, một Product Owner và các Developers. Không có sub-team hay hệ thống phân cấp bên trong Scrum Team.',
+     ARRAY['scrum-team'], '{}'::uuid[], owner),
+
+    -- 11
+    (q11, 'PSM-I',
+     'What is the recommended size for a Scrum Team?',
+     'The Scrum Team should be small enough to remain nimble and large enough to complete significant work within a Sprint — typically 10 or fewer people. If teams become too large, they should consider reorganizing into multiple cohesive Scrum Teams.',
+     'Scrum Team đủ nhỏ để linh hoạt và đủ lớn để hoàn thành công việc đáng kể trong một Sprint — thường từ 10 người trở xuống.',
+     ARRAY['scrum-team', 'team-size'], '{}'::uuid[], owner),
+
+    -- 12
+    (q12, 'PSM-I',
+     'What is the maximum timebox for the Sprint Review for a one-month Sprint?',
+     'The Sprint Review is timeboxed to a maximum of 4 hours for a one-month Sprint. For shorter Sprints, the event is usually shorter.',
+     'Sprint Review được giới hạn tối đa 4 giờ cho Sprint một tháng. Sprint ngắn hơn thường có Sprint Review ngắn hơn tương ứng.',
+     ARRAY['sprint-review', 'timebox'], '{}'::uuid[], owner),
+
+    -- 13
+    (q13, 'PSM-I',
+     'What is the maximum timebox for the Sprint Retrospective for a one-month Sprint?',
+     'The Sprint Retrospective is timeboxed to a maximum of 3 hours for a one-month Sprint. The Scrum Team inspects how the last Sprint went with regards to individuals, interactions, processes, tools, and the Definition of Done.',
+     'Sprint Retrospective được giới hạn tối đa 3 giờ cho Sprint một tháng. Scrum Team kiểm tra cách Sprint vừa diễn ra liên quan đến con người, tương tác, quy trình và công cụ.',
+     ARRAY['sprint-retrospective', 'timebox'], '{}'::uuid[], owner),
+
+    -- 14
+    (q14, 'PSM-I',
+     'Who is responsible for creating the Definition of Done when there is no existing organizational standard?',
+     'If the Definition of Done is not a standard of the organization, the Developers of the Scrum Team must create a Definition of Done appropriate for the product. The Scrum Master ensures the team has one.',
+     'Nếu tổ chức không có tiêu chuẩn Definition of Done, các Developers của Scrum Team phải tự tạo DoD phù hợp với sản phẩm của họ.',
+     ARRAY['definition-of-done'], '{}'::uuid[], owner),
+
+    -- 15
+    (q15, 'PSM-I',
+     'Which of the following is one of Scrum''s three pillars of empiricism but NOT one of the five Scrum values?',
+     'The three pillars are Transparency, Inspection, and Adaptation. The five Scrum values are: Commitment, Focus, Openness, Respect, and Courage. Transparency is a pillar, not a value.',
+     'Ba trụ cột là: Transparency, Inspection, Adaptation. Năm giá trị Scrum là: Commitment, Focus, Openness, Respect, Courage. Transparency là trụ cột, không phải giá trị.',
+     ARRAY['empiricism', 'scrum-values'], '{}'::uuid[], owner),
+
+    -- 16
+    (q16, 'PSM-I',
+     'When multiple Scrum Teams are working on the same product, how many Product Backlogs should there be?',
+     'There is one Product Backlog per product, regardless of how many Scrum Teams work on it. Having one Product Backlog ensures a single source of truth for priorities and goals.',
+     'Chỉ có một Product Backlog cho mỗi sản phẩm, dù có bao nhiêu Scrum Team cùng làm việc. Điều này đảm bảo có một nguồn thông tin duy nhất về thứ tự ưu tiên.',
+     ARRAY['product-backlog'], '{}'::uuid[], owner),
+
+    -- 17
+    (q17, 'PSM-I',
+     'Who is responsible for sizing (estimating) Product Backlog items?',
+     'The Developers who will be doing the work are responsible for the sizing of Product Backlog items. The Product Owner may influence by helping Developers understand and select trade-offs.',
+     'Các Developers thực hiện công việc chịu trách nhiệm ước lượng kích thước của các Product Backlog item. Product Owner có thể hỗ trợ bằng cách làm rõ yêu cầu và trade-off.',
+     ARRAY['product-backlog', 'estimation'], '{}'::uuid[], owner),
+
+    -- 18
+    (q18, 'PSM-I',
+     'When is the Sprint Goal created?',
+     'The Sprint Goal is created during Sprint Planning. It is the single objective for the Sprint and is crafted collaboratively by the Scrum Team. After Sprint Planning, the Developers inform the Product Owner of the Sprint Goal.',
+     'Sprint Goal được tạo ra trong quá trình Sprint Planning. Đây là mục tiêu duy nhất cho Sprint, được tạo ra cùng nhau bởi Scrum Team.',
+     ARRAY['sprint-goal', 'sprint-planning'], '{}'::uuid[], owner),
+
+    -- 19
+    (q19, 'PSM-I',
+     'What is the primary purpose of the Daily Scrum?',
+     'The Daily Scrum''s purpose is to inspect progress toward the Sprint Goal and adapt the Sprint Backlog as necessary, adjusting the upcoming planned work. It is not a status meeting for management.',
+     'Mục đích của Daily Scrum là thanh tra tiến độ hướng tới Sprint Goal và thích nghi Sprint Backlog nếu cần. Đây không phải là cuộc họp báo cáo cho ban quản lý.',
+     ARRAY['daily-scrum', 'sprint-goal'], '{}'::uuid[], owner),
+
+    -- 20
+    (q20, 'PSM-I',
+     'Which description best fits the Scrum Master role?',
+     'The Scrum Master is a servant leader who serves the Scrum Team and the larger organization. They help everyone understand Scrum theory and practice, and remove impediments to the Scrum Team''s progress.',
+     'Scrum Master là người lãnh đạo phục vụ cho Scrum Team và tổ chức. Họ giúp mọi người hiểu lý thuyết và thực hành Scrum, đồng thời loại bỏ các trở ngại cho Scrum Team.',
+     ARRAY['scrum-master', 'servant-leader'], '{}'::uuid[], owner),
+
+    -- 21
+    (q21, 'PSM-I',
+     'What happens to incomplete Product Backlog items at the end of a Sprint?',
+     'Incomplete Product Backlog items are returned to the Product Backlog. They are re-estimated and re-prioritized by the Product Owner in the next refinement cycle. The Sprint is NOT extended.',
+     'Các Product Backlog item chưa hoàn thành được trả lại Product Backlog. Product Owner sẽ ước lượng lại và sắp xếp thứ tự ưu tiên trong chu kỳ refinement tiếp theo. Sprint không được kéo dài.',
+     ARRAY['sprint', 'product-backlog'], '{}'::uuid[], owner),
+
+    -- 22
+    (q22, 'PSM-I',
+     'Which statement about the Sprint Backlog is correct?',
+     'The Sprint Backlog is updated throughout the Sprint as Developers learn more. Only Developers can change the Sprint Backlog; the Product Owner does not modify it unilaterally.',
+     'Sprint Backlog được cập nhật liên tục trong suốt Sprint khi Developers học được nhiều hơn. Chỉ Developers mới có thể thay đổi Sprint Backlog.',
+     ARRAY['sprint-backlog'], '{}'::uuid[], owner),
+
+    -- 23
+    (q23, 'PSM-I',
+     'What best describes Product Backlog refinement?',
+     'Product Backlog refinement is the act of breaking down and further defining Product Backlog items into smaller, more precise items. This is an ongoing activity in which the Product Owner and the Scrum Team collaborate.',
+     'Product Backlog refinement là hoạt động phân tách và làm rõ thêm các Product Backlog item thành các mục nhỏ hơn, chính xác hơn. Đây là hoạt động liên tục giữa Product Owner và Scrum Team.',
+     ARRAY['product-backlog', 'refinement'], '{}'::uuid[], owner),
+
+    -- 24
+    (q24, 'PSM-I',
+     'What is the Product Goal?',
+     'The Product Goal describes a future state of the product which can serve as a target for the Scrum Team to plan against. It is the commitment for the Product Backlog and represents the long-term objective.',
+     'Product Goal mô tả trạng thái tương lai của sản phẩm mà Scrum Team hướng đến. Đây là cam kết của Product Backlog và là mục tiêu dài hạn cho Scrum Team.',
+     ARRAY['product-goal', 'product-backlog'], '{}'::uuid[], owner),
+
+    -- 25
+    (q25, 'PSM-I',
+     'Which statement best describes an Increment?',
+     'An Increment is a concrete stepping stone toward the Product Goal. Each Increment is additive to all prior Increments and thoroughly verified, ensuring that all Increments work together. An Increment must be usable.',
+     'Increment là một bước cụ thể hướng tới Product Goal. Mỗi Increment bổ sung cho tất cả các Increment trước đó và được xác minh kỹ lưỡng. Increment phải có thể sử dụng được.',
+     ARRAY['increment', 'product-goal'], '{}'::uuid[], owner),
+
+    -- 26
+    (q26, 'PSM-I',
+     'Which of the following is the complete set of Scrum values?',
+     'The five Scrum values are: Commitment, Focus, Openness, Respect, and Courage. When these values are embodied and lived by the Scrum Team, the Scrum pillars of Transparency, Inspection, and Adaptation come to life.',
+     'Năm giá trị Scrum là: Commitment (Cam kết), Focus (Tập trung), Openness (Cởi mở), Respect (Tôn trọng) và Courage (Dũng cảm). Những giá trị này là nền tảng văn hóa của Scrum.',
+     ARRAY['scrum-values'], '{}'::uuid[], owner),
+
+    -- 27
+    (q27, 'PSM-I',
+     'What is the purpose of the Sprint Review?',
+     'The Sprint Review''s purpose is to inspect the outcome of the Sprint and determine future adaptations. The Scrum Team presents the results to key stakeholders and discusses progress toward the Product Goal. The Product Backlog may be adjusted.',
+     'Mục đích của Sprint Review là thanh tra kết quả của Sprint và xác định hướng thích nghi tiếp theo. Scrum Team trình bày kết quả cho các stakeholders chính và thảo luận về tiến độ hướng tới Product Goal.',
+     ARRAY['sprint-review', 'product-backlog'], '{}'::uuid[], owner),
+
+    -- 28
+    (q28, 'PSM-I',
+     'What is the primary purpose of the Sprint Retrospective?',
+     'The purpose of the Sprint Retrospective is to plan ways to increase quality and effectiveness. The Scrum Team inspects how the last Sprint went and identifies the most helpful improvements to implement next Sprint.',
+     'Mục đích của Sprint Retrospective là lên kế hoạch cải thiện chất lượng và hiệu quả. Scrum Team kiểm tra Sprint vừa qua và xác định các cải tiến hữu ích nhất để áp dụng vào Sprint tiếp theo.',
+     ARRAY['sprint-retrospective'], '{}'::uuid[], owner),
+
+    -- 29
+    (q29, 'PSM-I',
+     'What does the Definition of Done provide for the Scrum Team?',
+     'The Definition of Done creates transparency by providing everyone a shared understanding of what work is considered complete. If a Product Backlog item does not meet the DoD, it cannot be released or presented at the Sprint Review.',
+     'Definition of Done tạo ra sự minh bạch bằng cách cung cấp hiểu biết chung về thế nào là "hoàn thành". Nếu một Product Backlog item không đáp ứng DoD, nó không thể phát hành hoặc trình bày tại Sprint Review.',
+     ARRAY['definition-of-done', 'transparency'], '{}'::uuid[], owner),
+
+    -- 30
+    (q30, 'PSM-I',
+     'Which statement best describes Scrum?',
+     'Scrum is a lightweight framework that helps people, teams, and organizations generate value through adaptive solutions for complex problems. It is intentionally incomplete, only defining the parts required to implement Scrum theory.',
+     'Scrum là một framework nhẹ giúp mọi người, nhóm và tổ chức tạo ra giá trị thông qua các giải pháp thích nghi cho các vấn đề phức tạp. Scrum cố tình không đầy đủ, chỉ định nghĩa những phần cần thiết.',
+     ARRAY['scrum', 'framework'], '{}'::uuid[], owner);
+
+  -- ────────────────────────────────────────────────────────────
+  -- Options
+  -- ────────────────────────────────────────────────────────────
+
+  -- Q1: Max Sprint length
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q1, 'Two weeks', false, 0),
+    (gen_random_uuid(), q1, 'One month', true, 1),
+    (gen_random_uuid(), q1, 'Six weeks', false, 2),
+    (gen_random_uuid(), q1, 'There is no maximum; it is up to the team', false, 3);
+
+  -- Q2: Who maximizes product value
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q2, 'The Scrum Master', false, 0),
+    (gen_random_uuid(), q2, 'The Developers', false, 1),
+    (gen_random_uuid(), q2, 'The Product Owner', true, 2),
+    (gen_random_uuid(), q2, 'The stakeholders', false, 3);
+
+  -- Q3: Daily Scrum timebox
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q3, '10 minutes', false, 0),
+    (gen_random_uuid(), q3, '15 minutes', true, 1),
+    (gen_random_uuid(), q3, '30 minutes', false, 2),
+    (gen_random_uuid(), q3, 'It has no timebox; it ends when everyone has reported', false, 3);
+
+  -- Q4: Who can cancel a Sprint
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q4, 'The Scrum Master', false, 0),
+    (gen_random_uuid(), q4, 'The Developers', false, 1),
+    (gen_random_uuid(), q4, 'The stakeholders', false, 2),
+    (gen_random_uuid(), q4, 'The Product Owner', true, 3);
+
+  -- Q5: Three pillars of empiricism
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q5, 'Planning, Execution, and Review', false, 0),
+    (gen_random_uuid(), q5, 'Transparency, Inspection, and Adaptation', true, 1),
+    (gen_random_uuid(), q5, 'Communication, Collaboration, and Commitment', false, 2),
+    (gen_random_uuid(), q5, 'Vision, Value, and Velocity', false, 3);
+
+  -- Q6: Multiple Increments in a Sprint
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q6, 'The Increment must be released at the end of every Sprint', false, 0),
+    (gen_random_uuid(), q6, 'Multiple Increments may be created within a Sprint', true, 1),
+    (gen_random_uuid(), q6, 'The Developers decide whether to release the Increment', false, 2),
+    (gen_random_uuid(), q6, 'An Increment is only usable after the Sprint Review', false, 3);
+
+  -- Q7: Sprint Planning timebox
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q7, '4 hours', false, 0),
+    (gen_random_uuid(), q7, '6 hours', false, 1),
+    (gen_random_uuid(), q7, '8 hours', true, 2),
+    (gen_random_uuid(), q7, '2 hours', false, 3);
+
+  -- Q8: Sprint Backlog commitment
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q8, 'The Product Goal', false, 0),
+    (gen_random_uuid(), q8, 'The Sprint Goal', true, 1),
+    (gen_random_uuid(), q8, 'The Definition of Done', false, 2),
+    (gen_random_uuid(), q8, 'The Release Plan', false, 3);
+
+  -- Q9: Scrum Master role
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q9, 'Managing the team''s workload and assigning tasks', false, 0),
+    (gen_random_uuid(), q9, 'Coaching the Scrum Team in self-management and cross-functionality', true, 1),
+    (gen_random_uuid(), q9, 'Approving completed Sprint Backlog items', false, 2),
+    (gen_random_uuid(), q9, 'Acting as a liaison between management and the Developers', false, 3);
+
+  -- Q10: Scrum Team composition
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q10, 'Product Owner, Scrum Master, and Team Lead', false, 0),
+    (gen_random_uuid(), q10, 'Product Owner, Scrum Master, and Developers', true, 1),
+    (gen_random_uuid(), q10, 'Developers only', false, 2),
+    (gen_random_uuid(), q10, 'Product Owner and Developers only', false, 3);
+
+  -- Q11: Scrum Team size
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q11, '3 to 5 people', false, 0),
+    (gen_random_uuid(), q11, '5 to 9 people', false, 1),
+    (gen_random_uuid(), q11, '10 or fewer people', true, 2),
+    (gen_random_uuid(), q11, 'There is no recommended size', false, 3);
+
+  -- Q12: Sprint Review timebox
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q12, '2 hours', false, 0),
+    (gen_random_uuid(), q12, '3 hours', false, 1),
+    (gen_random_uuid(), q12, '4 hours', true, 2),
+    (gen_random_uuid(), q12, '8 hours', false, 3);
+
+  -- Q13: Sprint Retrospective timebox
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q13, '1 hour', false, 0),
+    (gen_random_uuid(), q13, '2 hours', false, 1),
+    (gen_random_uuid(), q13, '3 hours', true, 2),
+    (gen_random_uuid(), q13, '4 hours', false, 3);
+
+  -- Q14: Who creates DoD
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q14, 'The Scrum Master defines the Definition of Done', false, 0),
+    (gen_random_uuid(), q14, 'The Product Owner defines the Definition of Done', false, 1),
+    (gen_random_uuid(), q14, 'The Developers of the Scrum Team define the Definition of Done', true, 2),
+    (gen_random_uuid(), q14, 'The stakeholders define the Definition of Done', false, 3);
+
+  -- Q15: Pillar not a value
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q15, 'Commitment', false, 0),
+    (gen_random_uuid(), q15, 'Openness', false, 1),
+    (gen_random_uuid(), q15, 'Transparency', true, 2),
+    (gen_random_uuid(), q15, 'Courage', false, 3);
+
+  -- Q16: Product Backlogs for multiple teams
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q16, 'One Product Backlog per Scrum Team', false, 0),
+    (gen_random_uuid(), q16, 'One Product Backlog for the entire product', true, 1),
+    (gen_random_uuid(), q16, 'Two Product Backlogs — one for features, one for bugs', false, 2),
+    (gen_random_uuid(), q16, 'As many as the Product Owners agree on', false, 3);
+
+  -- Q17: Who sizes PB items
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q17, 'The Scrum Master provides estimates to keep planning objective', false, 0),
+    (gen_random_uuid(), q17, 'The Product Owner estimates with input from stakeholders', false, 1),
+    (gen_random_uuid(), q17, 'The Developers who will do the work are responsible for sizing', true, 2),
+    (gen_random_uuid(), q17, 'An external project manager estimates the items', false, 3);
+
+  -- Q18: When is Sprint Goal created
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q18, 'Before Sprint Planning, by the Product Owner', false, 0),
+    (gen_random_uuid(), q18, 'During Sprint Planning, collaboratively by the Scrum Team', true, 1),
+    (gen_random_uuid(), q18, 'During the Daily Scrum on the first day of the Sprint', false, 2),
+    (gen_random_uuid(), q18, 'At the Sprint Review of the previous Sprint', false, 3);
+
+  -- Q19: Purpose of Daily Scrum
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q19, 'To report status to the Scrum Master and Product Owner', false, 0),
+    (gen_random_uuid(), q19, 'To inspect progress toward the Sprint Goal and adapt the Sprint Backlog', true, 1),
+    (gen_random_uuid(), q19, 'To resolve technical impediments blocking the team', false, 2),
+    (gen_random_uuid(), q19, 'To plan the next Sprint alongside the current one', false, 3);
+
+  -- Q20: Scrum Master description
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q20, 'A manager who directs the work of Developers', false, 0),
+    (gen_random_uuid(), q20, 'A servant leader who serves the Scrum Team and the organization', true, 1),
+    (gen_random_uuid(), q20, 'A coordinator between the Product Owner and Developers', false, 2),
+    (gen_random_uuid(), q20, 'A technical lead who makes architecture decisions for the team', false, 3);
+
+  -- Q21: Incomplete work at Sprint end
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q21, 'The Sprint is extended until the work is complete', false, 0),
+    (gen_random_uuid(), q21, 'Incomplete items are returned to the Product Backlog', true, 1),
+    (gen_random_uuid(), q21, 'The Scrum Master decides what to do with the incomplete work', false, 2),
+    (gen_random_uuid(), q21, 'Developers must work overtime to finish the incomplete items', false, 3);
+
+  -- Q22: Sprint Backlog during Sprint
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q22, 'The Sprint Backlog is fixed once Sprint Planning is complete', false, 0),
+    (gen_random_uuid(), q22, 'Only the Product Owner can change the Sprint Backlog', false, 1),
+    (gen_random_uuid(), q22, 'The Sprint Backlog is updated by Developers throughout the Sprint as more is learned', true, 2),
+    (gen_random_uuid(), q22, 'The Sprint Backlog cannot be changed once the Sprint begins', false, 3);
+
+  -- Q23: Product Backlog refinement
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q23, 'A formal Sprint event timeboxed to 2 hours', false, 0),
+    (gen_random_uuid(), q23, 'The act of breaking down and further defining Product Backlog items', true, 1),
+    (gen_random_uuid(), q23, 'The Scrum Master''s responsibility for keeping the backlog clean', false, 2),
+    (gen_random_uuid(), q23, 'A technique for removing items that are no longer needed', false, 3);
+
+  -- Q24: Product Goal
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q24, 'The revenue target the product must achieve', false, 0),
+    (gen_random_uuid(), q24, 'The long-term objective for the Scrum Team, and the commitment for the Product Backlog', true, 1),
+    (gen_random_uuid(), q24, 'A Sprint-level goal set during Sprint Planning', false, 2),
+    (gen_random_uuid(), q24, 'A daily goal set at each Daily Scrum', false, 3);
+
+  -- Q25: Increment definition
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q25, 'The list of features completed during a Sprint', false, 0),
+    (gen_random_uuid(), q25, 'A concrete stepping stone toward the Product Goal that is usable', true, 1),
+    (gen_random_uuid(), q25, 'The Sprint Backlog items moved to the "Done" column', false, 2),
+    (gen_random_uuid(), q25, 'The Product Backlog items selected for the next Sprint', false, 3);
+
+  -- Q26: Scrum values
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q26, 'Courage, Focus, Commitment, Respect, and Openness', true, 0),
+    (gen_random_uuid(), q26, 'Courage, Focus, Commitment, Honesty, and Openness', false, 1),
+    (gen_random_uuid(), q26, 'Courage, Speed, Commitment, Respect, and Openness', false, 2),
+    (gen_random_uuid(), q26, 'Courage, Focus, Trust, Respect, and Openness', false, 3);
+
+  -- Q27: Sprint Review purpose
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q27, 'A formal demo for stakeholders to approve completed features', false, 0),
+    (gen_random_uuid(), q27, 'To inspect the Increment and adapt the Product Backlog', true, 1),
+    (gen_random_uuid(), q27, 'An informal meeting for Developers to show their work to management', false, 2),
+    (gen_random_uuid(), q27, 'A formal acceptance test of completed features', false, 3);
+
+  -- Q28: Sprint Retrospective purpose
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q28, 'To review the Increment with key stakeholders', false, 0),
+    (gen_random_uuid(), q28, 'To plan improvements to quality and effectiveness for the next Sprint', true, 1),
+    (gen_random_uuid(), q28, 'To update the Product Backlog with new items', false, 2),
+    (gen_random_uuid(), q28, 'To estimate items for the upcoming Sprint', false, 3);
+
+  -- Q29: Definition of Done provides
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q29, 'A checklist of technical standards set by the Scrum Master', false, 0),
+    (gen_random_uuid(), q29, 'A shared understanding of what work is considered complete, creating transparency', true, 1),
+    (gen_random_uuid(), q29, 'A record of all bugs found during testing', false, 2),
+    (gen_random_uuid(), q29, 'A set of acceptance criteria defined per Sprint by stakeholders', false, 3);
+
+  -- Q30: Scrum definition
+  INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+    (gen_random_uuid(), q30, 'A methodology that prescribes exactly how teams should build products', false, 0),
+    (gen_random_uuid(), q30, 'A project management framework specific to software development', false, 1),
+    (gen_random_uuid(), q30, 'A lightweight framework for generating value through adaptive solutions for complex problems', true, 2),
+    (gen_random_uuid(), q30, 'A set of best practices for agile software development teams', false, 3);
+
+END $$;


### PR DESCRIPTION
- Every word in the question stem is now clickable (not just glossary terms). A phrase-aware greedy tokenizer (longest-match-first) detects multi-word Scrum terms (e.g. "Product Owner", "Sprint Goal") before falling back to per-word spans, so compound terms stay as single clickable units.

- Clicking a glossary term (indigo dashed underline) opens TermPopup as before. Clicking any other word (dotted slate underline) calls the OpenRouter edge function (primary: gemini-2.0-flash-exp:free, fallback: gemini-flash-1.5-8b) and caches the result in Supabase + Dexie tagged "ai-dịch" — each unique word is only paid for once across all sessions.

- TermPopup now shows the optional `note` field from TermSense and highlights the "ai-dịch" tag with a distinct indigo badge.

- Migration 003 adds `note text` column to term_senses.

- seed_scrum_open.sql adds 30 PSM-I questions covering all Scrum Guide 2020 topics: roles, events (with timeboxes), artifacts, pillars, and values.

https://claude.ai/code/session_01VvznxWRNFiWSyFFiM12TgB