### PR TITLE
Fix header layout on small screens after login

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -138,6 +138,51 @@ body {
 }
 
 /* ========================
+   Responsive — small screens (e.g. iPhone 11)
+   ======================== */
+@media (max-width: 600px) {
+  .navbar {
+    padding: 0.5rem 0.75rem;
+    gap: 0.4rem 0.5rem;
+  }
+
+  .navbar-brand {
+    margin-right: auto;
+  }
+
+  /* Nav links drop to their own full-width row below brand + user */
+  .navbar-links {
+    order: 3;
+    flex-basis: 100%;
+    justify-content: space-between;
+    gap: 0.25rem;
+  }
+
+  .navbar-links a {
+    padding: 0.4rem 0.6rem;
+    font-size: 0.85rem;
+  }
+
+  .navbar-user {
+    min-width: 0;
+    max-width: 60%;
+    gap: 0.4rem;
+  }
+
+  /* Truncate long names/emails instead of overflowing */
+  .navbar-user span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .navbar-user .btn-sm {
+    flex-shrink: 0;
+    padding: 0.35rem 0.6rem;
+  }
+}
+
+/* ========================
    Cards
    ======================== */
 .card {


### PR DESCRIPTION
Add a mobile breakpoint so the navbar no longer wraps chaotically on
narrow viewports (e.g. iPhone 11). Brand and user controls stay on the
top row while nav links move to their own full-width row, and long
names/emails truncate instead of overflowing.

https://claude.ai/code/session_01UfXXq8RzaCrN3xx8evGhv2