### PR TITLE
Quiz UX overhaul: radio/checkbox, no layout shift, source labels

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -357,39 +357,242 @@ body {
   padding: 0.75rem 1rem;
   text-align: left;
   font-size: 0.95rem;
-  transition: all 0.15s;
+  transition:
+    background-color 0.15s,
+    border-color 0.15s;
   width: 100%;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 0.75rem;
+  cursor: pointer;
+  position: relative;
+}
+
+.quiz-option.disabled {
+  cursor: default;
 }
 
 /* Hover only while no answer has been picked yet */
-.quiz-option:not(.correct):not(.incorrect):not(.selected):hover {
+.quiz-option:not(.correct):not(.incorrect):not(.missed):not(.disabled):hover {
   border-color: var(--primary);
 }
 
+/* User picked this option (pre-answer or post-answer) */
+.quiz-option.picked:not(.correct):not(.incorrect) {
+  border-color: var(--primary);
+  background: var(--primary-light);
+}
+
+/* Correct option after answer */
 .quiz-option.correct {
   border-color: var(--success);
   background: var(--success-light);
   color: var(--success);
 }
 
+/* User picked, wrong */
 .quiz-option.incorrect {
   border-color: var(--error);
   background: var(--error-light);
   color: var(--error);
 }
 
-/* Mark the option the user actually picked */
-.quiz-option.selected {
-  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.08);
+/* Correct option the user did NOT pick — softer green to differentiate */
+.quiz-option.missed {
+  border-color: var(--success);
+  background: transparent;
+  color: var(--success);
 }
-.quiz-option.selected.correct {
-  box-shadow: 0 0 0 3px rgba(46, 125, 50, 0.3);
+
+/* Native input — focus ring confined to it only */
+.option-input {
+  flex-shrink: 0;
+  width: 1.15rem;
+  height: 1.15rem;
+  margin: 0;
+  cursor: pointer;
+  accent-color: var(--primary);
 }
-.quiz-option.selected.incorrect {
-  box-shadow: 0 0 0 3px rgba(198, 40, 40, 0.3);
+
+.option-input:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.option-input:disabled {
+  cursor: default;
+}
+
+/* A/B/C/D letter — visual aid only, not interactive */
+.option-letter-label {
+  flex-shrink: 0;
+  width: 1.4rem;
+  height: 1.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
+.quiz-option.correct .option-letter-label,
+.quiz-option.missed .option-letter-label {
+  background: var(--success);
+  color: white;
+  border-color: var(--success);
+}
+
+.quiz-option.incorrect .option-letter-label {
+  background: var(--error);
+  color: white;
+  border-color: var(--error);
+}
+
+.option-text {
+  flex: 1;
+  text-align: left;
+}
+
+.option-mark {
+  flex-shrink: 0;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.quiz-option.correct .option-mark {
+  color: var(--success);
+}
+.quiz-option.incorrect .option-mark {
+  color: var(--error);
+}
+.quiz-option.missed .option-mark {
+  color: var(--success);
+}
+
+/* Hint shown only for multi-select questions */
+.multi-hint {
+  margin-top: 0.5rem;
+  padding: 0.4rem 0.7rem;
+  background: #fff8e1;
+  border: 1px solid #ffe082;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  color: #6d4c41;
+}
+
+/* Quality badge near exam tag */
+.quality-badge {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 20px;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: help;
+}
+
+.quality-badge.quality-trusted {
+  background: var(--success-light);
+  color: var(--success);
+  border: 1px solid var(--success);
+}
+
+.quality-badge.quality-reference {
+  background: #fff8e1;
+  color: #6d4c41;
+  border: 1px solid #ffe082;
+}
+
+/* Hint trigger (popover anchor) — positioned outside the card so the popover
+   floats over surroundings instead of expanding inline. */
+.hint-trigger-wrap {
+  position: relative;
+  margin-top: 0.5rem;
+}
+
+.hint-trigger-btn {
+  background: transparent;
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.82rem;
+  color: var(--primary);
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.hint-trigger-btn:hover {
+  background: var(--primary-light);
+}
+
+.hint-popover {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  right: 0;
+  z-index: 50;
+  padding: 0.75rem 1rem;
+  background: #fff8e1;
+  border: 1px solid #ffe082;
+  border-radius: 8px;
+  font-size: 0.88rem;
+  color: #5d4037;
+  line-height: 1.5;
+  box-shadow: var(--shadow);
+}
+
+/* Sticky bottom action bar after answering */
+.action-bar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem calc(0.6rem + env(safe-area-inset-bottom));
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.06);
+}
+
+.action-bar-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.action-bar-status-correct {
+  background: var(--success-light);
+  color: var(--success);
+}
+
+.action-bar-status-incorrect {
+  background: var(--error-light);
+  color: var(--error);
+}
+
+.action-bar-info {
+  flex-shrink: 0;
+}
+
+.action-bar-next {
+  margin-left: auto;
+}
+
+/* Reserve space at bottom of quiz card so sticky bar never overlaps options */
+.quiz-card-pad {
+  height: 70px;
 }
 
 /* ========================
@@ -642,76 +845,6 @@ progress::-webkit-progress-value {
   color: var(--primary);
 }
 
-/* Pre-answer hint box */
-.hint-section {
-  margin-bottom: 0.75rem;
-}
-
-.hint-box {
-  margin-top: 0.5rem;
-  padding: 0.75rem 1rem;
-  background: #fff8e1;
-  border: 1px solid #ffe082;
-  border-radius: 8px;
-  font-size: 0.88rem;
-  color: #5d4037;
-  line-height: 1.5;
-}
-
-/* Letter chip — the select-answer button */
-.option-letter {
-  flex-shrink: 0;
-  width: 1.6rem;
-  height: 1.6rem;
-  padding: 0;
-  border-radius: 6px;
-  background: var(--bg);
-  border: 1.5px solid var(--border);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 700;
-  font-size: 0.75rem;
-  color: var(--text-secondary);
-  transition: all 0.15s;
-  margin-top: 1px;
-  cursor: pointer;
-  font-family: inherit;
-}
-
-.option-letter:focus-visible {
-  outline: 2px solid var(--primary);
-  outline-offset: 2px;
-}
-
-.option-letter:disabled {
-  opacity: 1;
-  cursor: default;
-}
-
-.quiz-option:not(.correct):not(.incorrect):not(.selected):hover .option-letter {
-  background: var(--primary);
-  color: white;
-  border-color: var(--primary);
-}
-
-.quiz-option.correct .option-letter {
-  background: var(--success);
-  color: white;
-  border-color: var(--success);
-}
-
-.quiz-option.incorrect .option-letter {
-  background: var(--error);
-  color: white;
-  border-color: var(--error);
-}
-
-.option-text {
-  flex: 1;
-  text-align: left;
-}
-
 /* Session progress bar (above quiz card) */
 .quiz-progress-section {
   margin-bottom: 0.75rem;
@@ -739,28 +872,6 @@ progress::-webkit-progress-value {
   transition: width 0.3s ease;
 }
 
-/* Post-answer feedback row */
-.answer-feedback {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.6rem 0.75rem;
-  border-radius: 8px;
-  font-size: 0.9rem;
-  font-weight: 600;
-  margin-top: 1rem;
-}
-
-.answer-feedback-correct {
-  background: var(--success-light);
-  color: var(--success);
-}
-
-.answer-feedback-incorrect {
-  background: var(--error-light);
-  color: var(--error);
-}
-
 .answer-feedback-icon {
   font-size: 1rem;
 }
@@ -770,14 +881,6 @@ progress::-webkit-progress-value {
   font-size: 0.8rem;
   font-weight: 500;
   opacity: 0.8;
-}
-
-/* Post-answer explanation box */
-.explanation-box {
-  margin-top: 0.5rem;
-  padding: 0.75rem 1rem;
-  background: var(--primary-light);
-  border-radius: 8px;
 }
 
 /* Filter bar enhancements */
@@ -947,27 +1050,6 @@ progress::-webkit-progress-value {
 .translate-error {
   color: var(--error);
   font-style: italic;
-}
-
-/* Phrase selection → translate bar */
-.phrase-translate-bar {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.35rem 0.75rem;
-  background: var(--primary-light);
-  border-radius: 8px;
-  font-size: 0.82rem;
-  margin-top: 0.4rem;
-}
-
-.phrase-preview {
-  flex: 1;
-  font-style: italic;
-  color: var(--text-secondary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 /* Note field inside a TermSense */

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -15,9 +15,7 @@ export async function syncContent(force = false): Promise<void> {
 }
 
 async function syncTerms(): Promise<void> {
-  const { data, error } = await supabase
-    .from('terms')
-    .select('*, term_senses(*)');
+  const { data, error } = await supabase.from('terms').select('*, term_senses(*)');
 
   if (error) throw error;
   if (!data) return;
@@ -54,9 +52,7 @@ async function syncTerms(): Promise<void> {
 }
 
 async function syncQuestions(): Promise<void> {
-  const { data, error } = await supabase
-    .from('questions')
-    .select('*, question_options(*)');
+  const { data, error } = await supabase.from('questions').select('*, question_options(*)');
 
   if (error) throw error;
   if (!data) return;
@@ -70,6 +66,8 @@ async function syncQuestions(): Promise<void> {
     tags: q.tags ?? [],
     termRefs: q.term_refs ?? [],
     ownerId: q.owner_id,
+    source: q.source ?? undefined,
+    quality: q.quality === 'trusted' ? 'trusted' : 'reference',
   }));
 
   const options: QuestionOption[] = data.flatMap((q) =>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,8 @@ export interface TermSense {
   sortOrder: number;
 }
 
+export type QuestionQuality = 'trusted' | 'reference';
+
 export interface Question {
   id: string;
   exam: 'PSM-I' | 'PSPO-I';
@@ -28,6 +30,8 @@ export interface Question {
   tags: string[];
   termRefs: string[];
   ownerId: string;
+  source?: string;
+  quality: QuestionQuality;
   options?: QuestionOption[];
 }
 

--- a/src/routes/quiz/+page.svelte
+++ b/src/routes/quiz/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount } from 'svelte';
   import { db } from '$lib/db';
   import { progressMap, getProgress, saveProgress } from '$lib/stores/mastery';
   import { improveProgress, canPractice, shuffleByIndex, getBadge } from '$lib/srs';
@@ -23,25 +23,29 @@
   let lookedUpTermsData: Term[] = [];
 
   // Per-question UI state
-  let selectedOptionId: string | null = null;
+  let selectedIds: Set<string> = new Set();
   let answered = false;
   let options: QuestionOption[] = [];
   $: optionStems = options.map((o) => tokenizeStem(o.text, allTermsForTokenize));
   let termRefs: Term[] = [];
-  let showExplanation = false;
-  let showHint = false;
+  let showHintPopover = false;
+  let showExplanationSheet = false;
   let highlightedStem = '';
   let selectedTermId: string | null = null;
   let allTermsForTokenize: Term[] = [];
   let translatingWord: string | null = null;
   let translateError: string | null = null;
-  let phraseSelection: string | null = null;
 
   $: currentUserId = $authUser?.id;
   $: currentQ = sessionQuestions[sessionIndex] ?? null;
   $: progress = currentQ ? getProgress($progressMap, 'question', currentQ.id) : undefined;
-  $: selectedOpt = options.find((o) => o.id === selectedOptionId);
-  $: isCorrect = selectedOpt?.correct ?? false;
+  $: correctIds = new Set(options.filter((o) => o.correct).map((o) => o.id));
+  $: correctCount = correctIds.size;
+  $: isMulti = correctCount > 1;
+  $: isCorrect =
+    answered &&
+    selectedIds.size === correctCount &&
+    [...selectedIds].every((id) => correctIds.has(id));
   $: vocabCount = $sessionLookups.size;
   $: progressPct = sessionQuestions.length
     ? Math.round((sessionIndex / sessionQuestions.length) * 100)
@@ -69,13 +73,6 @@
       db.terms.toArray(),
     ]);
     initSession();
-    document.addEventListener('selectionchange', updatePhraseSelection);
-  });
-
-  onDestroy(() => {
-    if (typeof document !== 'undefined') {
-      document.removeEventListener('selectionchange', updatePhraseSelection);
-    }
   });
 
   function buildPool(filter: ExamFilter): Question[] {
@@ -91,8 +88,9 @@
     sessionDone = false;
     lookedUpTermsData = [];
     answered = false;
-    selectedOptionId = null;
-    showHint = false;
+    selectedIds = new Set();
+    showHintPopover = false;
+    showExplanationSheet = false;
     sessionLookups.set(new Map());
   }
 
@@ -103,19 +101,19 @@
 
   async function loadQuestion(q: Question) {
     answered = false;
-    selectedOptionId = null;
-    showExplanation = false;
-    showHint = false;
-    phraseSelection = null;
+    selectedIds = new Set();
+    showHintPopover = false;
+    showExplanationSheet = false;
 
     const [opts, refs] = await Promise.all([
       db.questionOptions.where('questionId').equals(q.id).toArray(),
-      q.termRefs.length
-        ? db.terms.where('id').anyOf(q.termRefs).toArray()
-        : Promise.resolve([]),
+      q.termRefs.length ? db.terms.where('id').anyOf(q.termRefs).toArray() : Promise.resolve([]),
     ]);
 
-    options = shuffleByIndex(opts.sort((a, b) => a.sortOrder - b.sortOrder), sessionIndex);
+    options = shuffleByIndex(
+      opts.sort((a, b) => a.sortOrder - b.sortOrder),
+      sessionIndex
+    );
     termRefs = refs;
     highlightedStem = tokenizeStem(q.stem, allTermsForTokenize);
   }
@@ -126,7 +124,6 @@
     const termEl = (e.target as HTMLElement).closest<HTMLElement>('[data-term-id]');
     if (termEl?.dataset.termId) {
       selectedTermId = termEl.dataset.termId;
-      phraseSelection = null;
       return;
     }
 
@@ -134,7 +131,6 @@
     const wordEl = (e.target as HTMLElement).closest<HTMLElement>('[data-word]');
     if (!wordEl?.dataset.word) return;
 
-    phraseSelection = null;
     const word = wordEl.dataset.word;
     translatingWord = word;
     translateError = null;
@@ -152,75 +148,40 @@
     }
   }
 
-  function updatePhraseSelection() {
-    const sel = window.getSelection();
-    const text = sel?.toString().trim() ?? '';
-    if (!text || !sel || sel.rangeCount === 0) {
-      phraseSelection = null;
-      return;
-    }
-    const node = sel.getRangeAt(0).commonAncestorContainer;
-    const el = node instanceof Element ? node : node.parentElement;
-    if (!el?.closest('.question-stem, .quiz-options')) {
-      phraseSelection = null;
-      return;
-    }
-    if (text.length > 2 && /\s/.test(text)) {
-      phraseSelection = text.replace(/\s+/g, ' ');
-    } else {
-      phraseSelection = null;
-    }
-  }
-
-  async function translatePhrase() {
-    if (!phraseSelection || !currentUserId || translatingWord) return;
-    const phrase = phraseSelection;
-    phraseSelection = null;
-    window.getSelection()?.removeAllRanges();
-    translatingWord = phrase;
-    translateError = null;
-    try {
-      const termId = await lookupOrTranslate(phrase, currentUserId);
-      allTermsForTokenize = await db.terms.toArray();
-      selectedTermId = termId;
-    } catch (err) {
-      console.error('Phrase translation failed:', err);
-      translateError = 'Dịch thất bại — thử lại sau';
-      setTimeout(() => (translateError = null), 3000);
-    } finally {
-      translatingWord = null;
-    }
-  }
-
-  function blurAnswerFocus() {
-    if (typeof document === 'undefined') return;
-    const active = document.activeElement;
-    if (active instanceof HTMLElement && active.closest('.quiz-options')) {
-      active.blur();
-    }
-  }
-
-  async function selectOption(opt: QuestionOption) {
+  async function toggleOption(opt: QuestionOption) {
     if (answered) return;
+
+    if (isMulti) {
+      // Multi: toggle, auto-submit when user has selected `correctCount` items
+      const next = new Set(selectedIds);
+      if (next.has(opt.id)) next.delete(opt.id);
+      else next.add(opt.id);
+      selectedIds = next;
+      if (next.size === correctCount) await submitAnswer();
+    } else {
+      // Single: pick → submit immediately
+      selectedIds = new Set([opt.id]);
+      await submitAnswer();
+    }
+  }
+
+  async function submitAnswer() {
     answered = true;
-    selectedOptionId = opt.id;
-    blurAnswerFocus();
-    if (opt.correct) sessionCorrect++;
+    const allCorrect =
+      selectedIds.size === correctCount && [...selectedIds].every((id) => correctIds.has(id));
+    if (allCorrect) sessionCorrect++;
     if (currentQ) {
-      await saveProgress(improveProgress(progress, 'question', currentQ.id, !opt.correct));
+      await saveProgress(improveProgress(progress, 'question', currentQ.id, !allCorrect));
     }
   }
 
   async function nextQuestion() {
-    blurAnswerFocus();
+    showHintPopover = false;
+    showExplanationSheet = false;
     if (sessionIndex >= sessionQuestions.length - 1) {
       await finishSession();
     } else {
       sessionIndex++;
-      answered = false;
-      selectedOptionId = null;
-      showExplanation = false;
-      showHint = false;
     }
   }
 
@@ -233,12 +194,20 @@
   }
 
   function optionClass(opt: QuestionOption): string {
-    if (!answered) return '';
+    if (!answered) return selectedIds.has(opt.id) ? 'picked' : '';
     const classes: string[] = [];
-    if (opt.id === selectedOptionId) classes.push('selected');
-    if (opt.correct) classes.push('correct');
-    else if (opt.id === selectedOptionId) classes.push('incorrect');
+    const picked = selectedIds.has(opt.id);
+    const correct = opt.correct;
+    if (picked) classes.push('picked');
+    if (correct) classes.push('correct');
+    if (picked && !correct) classes.push('incorrect');
+    if (!picked && correct) classes.push('missed');
     return classes.join(' ');
+  }
+
+  function qualityBadgeLabel(q: Question): string {
+    if (q.quality === 'trusted') return q.source ?? 'Scrum.org';
+    return q.source ? `Tham khảo · ${q.source}` : 'Tham khảo';
   }
 </script>
 
@@ -277,7 +246,6 @@
       </p>
     </div>
 
-    <!-- Score grid -->
     <div class="result-grid">
       <div class="result-stat">
         <div class="result-stat-value">{sessionCorrect}/{sessionQuestions.length}</div>
@@ -293,7 +261,6 @@
       </div>
     </div>
 
-    <!-- Readiness meter -->
     <div class="readiness-section">
       <div class="readiness-header">
         <span style="font-size:0.9rem;font-weight:600">Đánh giá Readiness:</span>
@@ -316,7 +283,6 @@
       </p>
     </div>
 
-    <!-- Vocab reinforcement list -->
     {#if lookedUpTermsData.length > 0}
       <div class="vocab-reinforce-section">
         <p class="vocab-reinforce-title">
@@ -339,7 +305,7 @@
     </button>
   </div>
 
-<!-- ── EMPTY STATE ── -->
+  <!-- ── EMPTY STATE ── -->
 {:else if sessionQuestions.length === 0}
   <div class="empty-state">
     {#if allQuestions.length === 0}
@@ -349,7 +315,7 @@
     {/if}
   </div>
 
-<!-- ── QUIZ CARD ── -->
+  <!-- ── QUIZ CARD ── -->
 {:else if currentQ}
   <!-- Progress bar -->
   <div class="quiz-progress-section">
@@ -359,6 +325,10 @@
       </span>
       <div class="flex items-center gap-1">
         <span class="tag" style="cursor:default">{currentQ.exam}</span>
+        <span class="quality-badge quality-{currentQ.quality}" title={currentQ.source ?? ''}>
+          {currentQ.quality === 'trusted' ? '🟢' : '🟡'}
+          {qualityBadgeLabel(currentQ)}
+        </span>
         <span>{getBadge(progress?.level ?? -1)}</span>
       </div>
     </div>
@@ -367,9 +337,8 @@
     </div>
   </div>
 
-  <div class="card">
-    <!-- Question stem with inline glossary highlights -->
-    <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <div class="card quiz-card">
+    <!-- Question stem -->
     <div
       class="question-stem"
       on:click={handleStemInteraction}
@@ -380,98 +349,129 @@
     </div>
 
     <p class="glossary-hint-label">
-      💡 Click từ đơn hoặc <em>bôi chọn cụm từ</em> để tra nghĩa
-      {#if translatingWord}<span class="translate-loading">· Đang dịch "{translatingWord}"…</span>{/if}
+      💡 Click từ trong câu để tra nghĩa
+      {#if translatingWord}<span class="translate-loading">· Đang dịch "{translatingWord}"…</span
+        >{/if}
       {#if translateError}<span class="translate-error">· {translateError}</span>{/if}
     </p>
-    {#if phraseSelection && currentUserId && !translatingWord}
-      <div class="phrase-translate-bar">
-        <span class="phrase-preview">"{phraseSelection}"</span>
-        <button class="btn btn-sm btn-primary" on:click={translatePhrase}>Dịch cụm</button>
-        <button class="btn btn-sm btn-ghost" on:click={() => { phraseSelection = null; window.getSelection()?.removeAllRanges(); }}>✕</button>
+
+    <!-- Multi-select hint -->
+    {#if isMulti}
+      <div class="multi-hint">
+        ☑ Chọn {correctCount} đáp án — tự động chấm khi đủ
       </div>
     {/if}
 
-    <!-- Hint toggle (only visible before answering) -->
-    {#if currentQ.explanationVi && !answered}
-      <div class="hint-section">
-        <button class="btn btn-ghost btn-sm" on:click={() => (showHint = !showHint)}>
-          {showHint ? '▲ Ẩn gợi ý' : '💡 Gợi ý tư duy'}
-        </button>
-        {#if showHint}
-          <div class="hint-box">{currentQ.explanationVi}</div>
-        {/if}
-      </div>
-    {/if}
-
-    <!-- Answer options: chip button selects, text supports word lookup -->
+    <!-- Answer options -->
     <div class="quiz-options">
       {#each options as opt, i}
-        <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-        <div
-          class="quiz-option {optionClass(opt)}"
-          on:click={handleStemInteraction}
-          on:keydown={handleStemInteraction}
-        >
-          <button
-            class="option-letter"
-            on:click|stopPropagation={() => selectOption(opt)}
+        <label class="quiz-option {optionClass(opt)}" class:disabled={answered}>
+          <input
+            type={isMulti ? 'checkbox' : 'radio'}
+            name="quiz-answer-{currentQ.id}"
+            class="option-input"
+            checked={selectedIds.has(opt.id)}
             disabled={answered}
-            aria-label="Chọn đáp án {String.fromCharCode(65 + i)}"
-          >
-            {String.fromCharCode(65 + i)}
-          </button>
+            on:change={() => toggleOption(opt)}
+          />
+          <span class="option-letter-label">{String.fromCharCode(65 + i)}</span>
           <span class="option-text">{@html optionStems[i] ?? opt.text}</span>
-        </div>
+          {#if answered}
+            <span class="option-mark">
+              {#if opt.correct}✓{:else if selectedIds.has(opt.id)}✗{/if}
+            </span>
+          {/if}
+        </label>
       {/each}
     </div>
 
-    <!-- Post-answer feedback -->
+    <!-- Pad bottom so sticky bar doesn't overlap content -->
     {#if answered}
-      <div class="answer-feedback answer-feedback-{isCorrect ? 'correct' : 'incorrect'}">
+      <div class="quiz-card-pad" aria-hidden="true"></div>
+    {/if}
+  </div>
+
+  <!-- Hint button + popover (pre-answer only) -->
+  {#if currentQ.explanationVi && !answered}
+    <div class="hint-trigger-wrap">
+      <button
+        class="hint-trigger-btn"
+        on:click={() => (showHintPopover = !showHintPopover)}
+        aria-expanded={showHintPopover}
+      >
+        {showHintPopover ? '▲ Ẩn gợi ý' : '💡 Gợi ý tư duy'}
+      </button>
+      {#if showHintPopover}
+        <div class="hint-popover" role="tooltip">
+          {currentQ.explanationVi}
+        </div>
+      {/if}
+    </div>
+  {/if}
+
+  <!-- Sticky bottom action bar (post-answer) -->
+  {#if answered}
+    <div class="action-bar" role="region" aria-label="Kết quả câu">
+      <div class="action-bar-status action-bar-status-{isCorrect ? 'correct' : 'incorrect'}">
         <span class="answer-feedback-icon">{isCorrect ? '✓' : '✗'}</span>
-        <span>{isCorrect ? 'Chính xác!' : 'Sai rồi!'}</span>
+        <span>{isCorrect ? 'Chính xác' : 'Chưa đúng'}</span>
         <span class="session-live-score">{sessionCorrect}/{sessionIndex + 1}</span>
       </div>
-
-      {#if currentQ.explanationVi || currentQ.explanationEn}
+      {#if currentQ.explanationVi || currentQ.explanationEn || termRefs.length}
         <button
-          class="btn btn-ghost btn-sm"
-          on:click={() => (showExplanation = !showExplanation)}
-          style="margin-top:0.75rem"
+          class="btn btn-ghost btn-sm action-bar-info"
+          on:click={() => (showExplanationSheet = true)}
+          aria-label="Xem giải thích"
         >
-          {showExplanation ? '▲ Ẩn giải thích' : '▼ Xem giải thích đầy đủ'}
+          ℹ️ Giải thích
         </button>
-        {#if showExplanation}
-          <div class="explanation-box">
-            {#if currentQ.explanationVi}
-              <p style="font-size:0.9rem">{currentQ.explanationVi}</p>
-            {/if}
-            {#if currentQ.explanationEn}
-              <p class="text-secondary mt-1" style="font-size:0.85rem">{currentQ.explanationEn}</p>
-            {/if}
-          </div>
-        {/if}
       {/if}
+      <button class="btn btn-primary btn-sm action-bar-next" on:click={nextQuestion}>
+        {sessionIndex < sessionQuestions.length - 1 ? 'Câu tiếp ▶' : '🎓 Xem kết quả'}
+      </button>
+    </div>
+  {/if}
 
+  <!-- Explanation sheet (overlay, slides up) -->
+  {#if showExplanationSheet}
+    <div
+      class="gloss-overlay"
+      on:click={() => (showExplanationSheet = false)}
+      role="presentation"
+    ></div>
+    <div class="gloss-popup" role="dialog" aria-modal="true" aria-label="Giải thích">
+      <button class="gloss-close" on:click={() => (showExplanationSheet = false)} aria-label="Đóng"
+        >✕</button
+      >
+      <h3 style="margin:0 0 0.75rem 0;font-size:1rem">📖 Giải thích</h3>
+      {#if currentQ.explanationVi}
+        <p style="font-size:0.9rem;line-height:1.55">{currentQ.explanationVi}</p>
+      {/if}
+      {#if currentQ.explanationEn}
+        <p class="text-secondary mt-1" style="font-size:0.85rem;line-height:1.5">
+          {currentQ.explanationEn}
+        </p>
+      {/if}
       {#if termRefs.length}
         <div class="mt-2">
-          <p class="text-secondary" style="font-size:0.8rem;margin-bottom:0.4rem">
+          <p class="text-secondary" style="font-size:0.78rem;margin-bottom:0.4rem">
             📌 Thuật ngữ trong câu hỏi:
           </p>
           <div class="tags">
             {#each termRefs as term}
-              <button class="tag" on:click={() => (selectedTermId = term.id)}>{term.text}</button>
+              <button
+                class="tag"
+                on:click={() => {
+                  showExplanationSheet = false;
+                  selectedTermId = term.id;
+                }}>{term.text}</button
+              >
             {/each}
           </div>
         </div>
       {/if}
-
-      <button class="btn btn-primary mt-2" style="width:100%" on:click={nextQuestion}>
-        {sessionIndex < sessionQuestions.length - 1 ? 'Câu tiếp theo ▶' : '🎓 Xem kết quả phiên'}
-      </button>
-    {/if}
-  </div>
+    </div>
+  {/if}
 {/if}
 
 <!-- Term detail popup -->

--- a/supabase/migrations/005_question_source.sql
+++ b/supabase/migrations/005_question_source.sql
@@ -1,0 +1,24 @@
+-- ============================================================
+-- Add provenance + quality label to questions
+-- Cleanup self-generated test questions previously seeded via seed.sql
+-- Tag existing Scrum Open Assessment questions as trusted
+-- ============================================================
+
+ALTER TABLE public.questions
+  ADD COLUMN IF NOT EXISTS source  text,
+  ADD COLUMN IF NOT EXISTS quality text NOT NULL DEFAULT 'reference'
+    CHECK (quality IN ('trusted', 'reference'));
+
+-- Drop the 3 sample questions inserted by supabase/seed.sql
+DELETE FROM public.questions
+  WHERE stem IN (
+    'Who is accountable for managing the Product Backlog?',
+    'During a Sprint, when is it appropriate to update the Sprint Goal?',
+    'Which statement best describes the role of the Scrum Master during the Daily Scrum?'
+  );
+
+-- Promote the public Scrum Open Assessment seed to "trusted"
+UPDATE public.questions
+  SET source  = 'Scrum Open Assessment',
+      quality = 'trusted'
+  WHERE owner_id IS NULL;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,9 +1,12 @@
 -- ============================================================
--- Seed data — 5 Scrum terms + 3 PSM-I questions (sample)
+-- Seed data — 5 Scrum terms (per-owner)
 -- Run AFTER creating your user account and replacing YOUR_USER_ID
 -- ============================================================
 -- Replace 'YOUR_USER_ID' with your actual auth.users uuid:
 --   SELECT id FROM auth.users WHERE email = 'your@email.com';
+-- ============================================================
+-- Note: questions are seeded separately via seed_scrum_open.sql
+-- (public, sourced from scrum.org Open Assessment).
 -- ============================================================
 
 DO $$
@@ -16,11 +19,6 @@ DECLARE
   t_sm      uuid := gen_random_uuid();
   t_spgoal  uuid := gen_random_uuid();
   t_pbref   uuid := gen_random_uuid();
-
-  -- Question IDs
-  q1 uuid := gen_random_uuid();
-  q2 uuid := gen_random_uuid();
-  q3 uuid := gen_random_uuid();
 BEGIN
 
   -- ---- Terms ----
@@ -68,52 +66,5 @@ BEGIN
                          'Hoạt động liên tục xem xét và cập nhật các hạng mục backlog.', 0),
     (t_pbref, 'scrum',   'The act of breaking down and further defining Product Backlog items into smaller more precise items. An ongoing activity, not a formal Scrum event.',
                          'Việc phân tách và làm rõ các hạng mục Product Backlog thành các phần nhỏ hơn, chính xác hơn. Đây là hoạt động LIÊN TỤC, KHÔNG phải một sự kiện Scrum chính thức.', 1);
-
-  -- ---- Questions ----
-
-  INSERT INTO public.questions (id, exam, stem, explanation_en, explanation_vi, tags, term_refs, owner_id) VALUES
-    (q1, 'PSM-I',
-     'Who is accountable for managing the Product Backlog?',
-     'The Product Owner is solely accountable for Product Backlog management, including its content, availability, and ordering. However, the Product Owner may delegate the work to others.',
-     'Product Owner là người DUY NHẤT chịu trách nhiệm quản lý Product Backlog — nội dung, sự sẵn sàng, và thứ tự ưu tiên. Tuy nhiên, PO có thể ủy thác công việc cho người khác.',
-     ARRAY['role','product-backlog'],
-     ARRAY[t_po], owner),
-
-    (q2, 'PSM-I',
-     'During a Sprint, when is it appropriate to update the Sprint Goal?',
-     'The Sprint Goal is committed to during Sprint Planning and should not change during the Sprint. The scope can be renegotiated, but not the Sprint Goal itself.',
-     'Sprint Goal được cam kết trong Sprint Planning và KHÔNG được thay đổi trong Sprint. Chỉ scope (nội dung công việc) mới có thể điều chỉnh để đạt Goal, không phải Goal.',
-     ARRAY['sprint','sprint-goal'],
-     ARRAY[t_spgoal], owner),
-
-    (q3, 'PSM-I',
-     'Which statement best describes the role of the Scrum Master during the Daily Scrum?',
-     'The Daily Scrum is an event for the Developers. The Scrum Master does not run it. The Scrum Master teaches the Developers to keep the Daily Scrum within 15 minutes, but the Developers own the meeting.',
-     'Daily Scrum là sự kiện của Developers. Scrum Master KHÔNG điều hành nó. SM đảm bảo sự kiện diễn ra nhưng Developers tự tổ chức — đây là điểm hay bị nhầm trong thi cử.',
-     ARRAY['event','scrum-master','daily-scrum'],
-     ARRAY[t_sm], owner);
-
-  -- ---- Question Options ----
-
-  -- Q1: Who manages Product Backlog?
-  INSERT INTO public.question_options (question_id, text, correct, sort_order) VALUES
-    (q1, 'The Product Owner',                                          true,  0),
-    (q1, 'The Scrum Master',                                           false, 1),
-    (q1, 'The Scrum Team as a whole',                                  false, 2),
-    (q1, 'The stakeholders who requested the features',                false, 3);
-
-  -- Q2: Sprint Goal change
-  INSERT INTO public.question_options (question_id, text, correct, sort_order) VALUES
-    (q2, 'Never — the Sprint Goal is fixed once the Sprint starts',    true,  0),
-    (q2, 'Whenever the Product Owner requests it',                     false, 1),
-    (q2, 'When the Developers discover it is unachievable',            false, 2),
-    (q2, 'During the Daily Scrum if the team agrees',                  false, 3);
-
-  -- Q3: Scrum Master at Daily Scrum
-  INSERT INTO public.question_options (question_id, text, correct, sort_order) VALUES
-    (q3, 'Ensures the event happens; Developers run it themselves',    true,  0),
-    (q3, 'Facilitates the meeting and asks each Developer their update', false, 1),
-    (q3, 'Takes notes and reports status to management',               false, 2),
-    (q3, 'The Scrum Master is not required to attend',                 false, 3);
 
 END $$;

--- a/supabase/seed_scrum_open.sql
+++ b/supabase/seed_scrum_open.sql
@@ -25,217 +25,217 @@ BEGIN
   -- Questions
   -- ────────────────────────────────────────────────────────────
   INSERT INTO public.questions
-    (id, exam, stem, explanation_en, explanation_vi, tags, term_refs)
+    (id, exam, stem, explanation_en, explanation_vi, tags, term_refs, source, quality)
   VALUES
     -- 1
     (q1, 'PSM-I',
      'What is the maximum length of a Sprint?',
      'The Scrum Guide states Sprints are one month or less. No Sprint may be longer than one month. When a Sprint''s horizon is too long, the Sprint Goal may become invalid and complexity may rise.',
      'Scrum Guide quy định Sprint có thời gian tối đa là một tháng. Sprint dài hơn có thể khiến Sprint Goal mất giá trị và rủi ro gia tăng.',
-     ARRAY['sprint', 'timebox'], '{}'::uuid[]),
+     ARRAY['sprint', 'timebox'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 2
     (q2, 'PSM-I',
      'Who is accountable for maximizing the value of the product resulting from the work of the Scrum Team?',
      'The Product Owner is accountable for maximizing the value of the product resulting from the work of the Scrum Team. How this is done may vary widely across organizations, Scrum Teams, and individuals.',
      'Product Owner chịu trách nhiệm tối đa hóa giá trị của sản phẩm từ công việc của Scrum Team. Cách thực hiện có thể khác nhau tùy tổ chức.',
-     ARRAY['product-owner', 'accountability'], '{}'::uuid[]),
+     ARRAY['product-owner', 'accountability'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 3
     (q3, 'PSM-I',
      'What is the timebox for the Daily Scrum?',
      'The Daily Scrum is a 15-minute event for the Developers of the Scrum Team. To reduce complexity, it is held at the same time and place every working day of the Sprint.',
      'Daily Scrum là sự kiện 15 phút dành cho Developers. Được tổ chức cùng giờ, cùng địa điểm mỗi ngày làm việc trong Sprint để giảm phức tạp.',
-     ARRAY['daily-scrum', 'timebox'], '{}'::uuid[]),
+     ARRAY['daily-scrum', 'timebox'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 4
     (q4, 'PSM-I',
      'Who has the authority to cancel a Sprint?',
      'Only the Product Owner has the authority to cancel a Sprint. A Sprint would be cancelled if the Sprint Goal becomes obsolete. This is a rare occurrence.',
      'Chỉ Product Owner mới có quyền hủy Sprint. Sprint bị hủy khi Sprint Goal trở nên lỗi thời. Đây là trường hợp hiếm gặp.',
-     ARRAY['sprint', 'product-owner', 'cancellation'], '{}'::uuid[]),
+     ARRAY['sprint', 'product-owner', 'cancellation'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 5
     (q5, 'PSM-I',
      'Which three pillars uphold every implementation of empirical process control?',
      'The three pillars of empiricism are Transparency, Inspection, and Adaptation. Scrum combines these pillars to make decisions based on what is observed rather than speculation.',
      'Ba trụ cột của chủ nghĩa kinh nghiệm trong Scrum là Minh bạch (Transparency), Thanh tra (Inspection) và Thích nghi (Adaptation). Đây là nền tảng cho mọi quyết định dựa trên thực tế quan sát được.',
-     ARRAY['empiricism', 'transparency', 'inspection', 'adaptation'], '{}'::uuid[]),
+     ARRAY['empiricism', 'transparency', 'inspection', 'adaptation'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 6
     (q6, 'PSM-I',
      'Which statement about the Increment is correct?',
      'Multiple Increments may be created within a Sprint. The sum of the Increments is presented at the Sprint Review, supporting empiricism. The Product Owner may decide to release any Increment before the Sprint ends.',
      'Nhiều Increment có thể được tạo ra trong một Sprint. Product Owner có thể quyết định phát hành bất kỳ Increment nào trước khi Sprint kết thúc.',
-     ARRAY['increment', 'sprint'], '{}'::uuid[]),
+     ARRAY['increment', 'sprint'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 7
     (q7, 'PSM-I',
      'What is the maximum timebox for Sprint Planning for a one-month Sprint?',
      'Sprint Planning is timeboxed to a maximum of 8 hours for a one-month Sprint. For shorter Sprints, the event is usually shorter.',
      'Sprint Planning được giới hạn tối đa 8 giờ cho Sprint một tháng. Sprint ngắn hơn thường có Sprint Planning ngắn hơn tương ứng.',
-     ARRAY['sprint-planning', 'timebox'], '{}'::uuid[]),
+     ARRAY['sprint-planning', 'timebox'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 8
     (q8, 'PSM-I',
      'What is the commitment for the Sprint Backlog?',
      'The Sprint Goal is the commitment for the Sprint Backlog. The Sprint Goal is the single objective for the Sprint and provides flexibility to Developers while maintaining focus.',
      'Sprint Goal là cam kết gắn với Sprint Backlog. Sprint Goal tạo ra sự linh hoạt cho Developers trong khi vẫn duy trì trọng tâm nhất quán.',
-     ARRAY['sprint-backlog', 'sprint-goal', 'commitment'], '{}'::uuid[]),
+     ARRAY['sprint-backlog', 'sprint-goal', 'commitment'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 9
     (q9, 'PSM-I',
      'Which of the following best describes the Scrum Master''s role?',
      'The Scrum Master is accountable for establishing Scrum and coaching the Scrum Team in self-management and cross-functionality. The Scrum Master is a servant leader, not a manager who assigns work.',
      'Scrum Master chịu trách nhiệm thiết lập Scrum và huấn luyện Scrum Team về tự quản lý và đa chức năng. Scrum Master là người lãnh đạo phục vụ, không phải quản lý phân công công việc.',
-     ARRAY['scrum-master', 'servant-leader'], '{}'::uuid[]),
+     ARRAY['scrum-master', 'servant-leader'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 10
     (q10, 'PSM-I',
      'Who are the members of a Scrum Team?',
      'A Scrum Team consists of one Scrum Master, one Product Owner, and Developers. There are no sub-teams or hierarchies within a Scrum Team; it is a cohesive unit of professionals.',
      'Scrum Team gồm một Scrum Master, một Product Owner và các Developers. Không có sub-team hay hệ thống phân cấp bên trong Scrum Team.',
-     ARRAY['scrum-team'], '{}'::uuid[]),
+     ARRAY['scrum-team'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 11
     (q11, 'PSM-I',
      'What is the recommended size for a Scrum Team?',
      'The Scrum Team should be small enough to remain nimble and large enough to complete significant work within a Sprint — typically 10 or fewer people. If teams become too large, they should consider reorganizing into multiple cohesive Scrum Teams.',
      'Scrum Team đủ nhỏ để linh hoạt và đủ lớn để hoàn thành công việc đáng kể trong một Sprint — thường từ 10 người trở xuống.',
-     ARRAY['scrum-team', 'team-size'], '{}'::uuid[]),
+     ARRAY['scrum-team', 'team-size'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 12
     (q12, 'PSM-I',
      'What is the maximum timebox for the Sprint Review for a one-month Sprint?',
      'The Sprint Review is timeboxed to a maximum of 4 hours for a one-month Sprint. For shorter Sprints, the event is usually shorter.',
      'Sprint Review được giới hạn tối đa 4 giờ cho Sprint một tháng. Sprint ngắn hơn thường có Sprint Review ngắn hơn tương ứng.',
-     ARRAY['sprint-review', 'timebox'], '{}'::uuid[]),
+     ARRAY['sprint-review', 'timebox'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 13
     (q13, 'PSM-I',
      'What is the maximum timebox for the Sprint Retrospective for a one-month Sprint?',
      'The Sprint Retrospective is timeboxed to a maximum of 3 hours for a one-month Sprint. The Scrum Team inspects how the last Sprint went with regards to individuals, interactions, processes, tools, and the Definition of Done.',
      'Sprint Retrospective được giới hạn tối đa 3 giờ cho Sprint một tháng. Scrum Team kiểm tra cách Sprint vừa diễn ra liên quan đến con người, tương tác, quy trình và công cụ.',
-     ARRAY['sprint-retrospective', 'timebox'], '{}'::uuid[]),
+     ARRAY['sprint-retrospective', 'timebox'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 14
     (q14, 'PSM-I',
      'Who is responsible for creating the Definition of Done when there is no existing organizational standard?',
      'If the Definition of Done is not a standard of the organization, the Developers of the Scrum Team must create a Definition of Done appropriate for the product. The Scrum Master ensures the team has one.',
      'Nếu tổ chức không có tiêu chuẩn Definition of Done, các Developers của Scrum Team phải tự tạo DoD phù hợp với sản phẩm của họ.',
-     ARRAY['definition-of-done'], '{}'::uuid[]),
+     ARRAY['definition-of-done'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 15
     (q15, 'PSM-I',
      'Which of the following is one of Scrum''s three pillars of empiricism but NOT one of the five Scrum values?',
      'The three pillars are Transparency, Inspection, and Adaptation. The five Scrum values are: Commitment, Focus, Openness, Respect, and Courage. Transparency is a pillar, not a value.',
      'Ba trụ cột là: Transparency, Inspection, Adaptation. Năm giá trị Scrum là: Commitment, Focus, Openness, Respect, Courage. Transparency là trụ cột, không phải giá trị.',
-     ARRAY['empiricism', 'scrum-values'], '{}'::uuid[]),
+     ARRAY['empiricism', 'scrum-values'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 16
     (q16, 'PSM-I',
      'When multiple Scrum Teams are working on the same product, how many Product Backlogs should there be?',
      'There is one Product Backlog per product, regardless of how many Scrum Teams work on it. Having one Product Backlog ensures a single source of truth for priorities and goals.',
      'Chỉ có một Product Backlog cho mỗi sản phẩm, dù có bao nhiêu Scrum Team cùng làm việc. Điều này đảm bảo có một nguồn thông tin duy nhất về thứ tự ưu tiên.',
-     ARRAY['product-backlog'], '{}'::uuid[]),
+     ARRAY['product-backlog'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 17
     (q17, 'PSM-I',
      'Who is responsible for sizing (estimating) Product Backlog items?',
      'The Developers who will be doing the work are responsible for the sizing of Product Backlog items. The Product Owner may influence by helping Developers understand and select trade-offs.',
      'Các Developers thực hiện công việc chịu trách nhiệm ước lượng kích thước của các Product Backlog item. Product Owner có thể hỗ trợ bằng cách làm rõ yêu cầu và trade-off.',
-     ARRAY['product-backlog', 'estimation'], '{}'::uuid[]),
+     ARRAY['product-backlog', 'estimation'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 18
     (q18, 'PSM-I',
      'When is the Sprint Goal created?',
      'The Sprint Goal is created during Sprint Planning. It is the single objective for the Sprint and is crafted collaboratively by the Scrum Team. After Sprint Planning, the Developers inform the Product Owner of the Sprint Goal.',
      'Sprint Goal được tạo ra trong quá trình Sprint Planning. Đây là mục tiêu duy nhất cho Sprint, được tạo ra cùng nhau bởi Scrum Team.',
-     ARRAY['sprint-goal', 'sprint-planning'], '{}'::uuid[]),
+     ARRAY['sprint-goal', 'sprint-planning'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 19
     (q19, 'PSM-I',
      'What is the primary purpose of the Daily Scrum?',
      'The Daily Scrum''s purpose is to inspect progress toward the Sprint Goal and adapt the Sprint Backlog as necessary, adjusting the upcoming planned work. It is not a status meeting for management.',
      'Mục đích của Daily Scrum là thanh tra tiến độ hướng tới Sprint Goal và thích nghi Sprint Backlog nếu cần. Đây không phải là cuộc họp báo cáo cho ban quản lý.',
-     ARRAY['daily-scrum', 'sprint-goal'], '{}'::uuid[]),
+     ARRAY['daily-scrum', 'sprint-goal'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 20
     (q20, 'PSM-I',
      'Which description best fits the Scrum Master role?',
      'The Scrum Master is a servant leader who serves the Scrum Team and the larger organization. They help everyone understand Scrum theory and practice, and remove impediments to the Scrum Team''s progress.',
      'Scrum Master là người lãnh đạo phục vụ cho Scrum Team và tổ chức. Họ giúp mọi người hiểu lý thuyết và thực hành Scrum, đồng thời loại bỏ các trở ngại cho Scrum Team.',
-     ARRAY['scrum-master', 'servant-leader'], '{}'::uuid[]),
+     ARRAY['scrum-master', 'servant-leader'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 21
     (q21, 'PSM-I',
      'What happens to incomplete Product Backlog items at the end of a Sprint?',
      'Incomplete Product Backlog items are returned to the Product Backlog. They are re-estimated and re-prioritized by the Product Owner in the next refinement cycle. The Sprint is NOT extended.',
      'Các Product Backlog item chưa hoàn thành được trả lại Product Backlog. Product Owner sẽ ước lượng lại và sắp xếp thứ tự ưu tiên trong chu kỳ refinement tiếp theo. Sprint không được kéo dài.',
-     ARRAY['sprint', 'product-backlog'], '{}'::uuid[]),
+     ARRAY['sprint', 'product-backlog'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 22
     (q22, 'PSM-I',
      'Which statement about the Sprint Backlog is correct?',
      'The Sprint Backlog is updated throughout the Sprint as Developers learn more. Only Developers can change the Sprint Backlog; the Product Owner does not modify it unilaterally.',
      'Sprint Backlog được cập nhật liên tục trong suốt Sprint khi Developers học được nhiều hơn. Chỉ Developers mới có thể thay đổi Sprint Backlog.',
-     ARRAY['sprint-backlog'], '{}'::uuid[]),
+     ARRAY['sprint-backlog'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 23
     (q23, 'PSM-I',
      'What best describes Product Backlog refinement?',
      'Product Backlog refinement is the act of breaking down and further defining Product Backlog items into smaller, more precise items. This is an ongoing activity in which the Product Owner and the Scrum Team collaborate.',
      'Product Backlog refinement là hoạt động phân tách và làm rõ thêm các Product Backlog item thành các mục nhỏ hơn, chính xác hơn. Đây là hoạt động liên tục giữa Product Owner và Scrum Team.',
-     ARRAY['product-backlog', 'refinement'], '{}'::uuid[]),
+     ARRAY['product-backlog', 'refinement'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 24
     (q24, 'PSM-I',
      'What is the Product Goal?',
      'The Product Goal describes a future state of the product which can serve as a target for the Scrum Team to plan against. It is the commitment for the Product Backlog and represents the long-term objective.',
      'Product Goal mô tả trạng thái tương lai của sản phẩm mà Scrum Team hướng đến. Đây là cam kết của Product Backlog và là mục tiêu dài hạn cho Scrum Team.',
-     ARRAY['product-goal', 'product-backlog'], '{}'::uuid[]),
+     ARRAY['product-goal', 'product-backlog'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 25
     (q25, 'PSM-I',
      'Which statement best describes an Increment?',
      'An Increment is a concrete stepping stone toward the Product Goal. Each Increment is additive to all prior Increments and thoroughly verified, ensuring that all Increments work together. An Increment must be usable.',
      'Increment là một bước cụ thể hướng tới Product Goal. Mỗi Increment bổ sung cho tất cả các Increment trước đó và được xác minh kỹ lưỡng. Increment phải có thể sử dụng được.',
-     ARRAY['increment', 'product-goal'], '{}'::uuid[]),
+     ARRAY['increment', 'product-goal'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 26
     (q26, 'PSM-I',
      'Which of the following is the complete set of Scrum values?',
      'The five Scrum values are: Commitment, Focus, Openness, Respect, and Courage. When these values are embodied and lived by the Scrum Team, the Scrum pillars of Transparency, Inspection, and Adaptation come to life.',
      'Năm giá trị Scrum là: Commitment (Cam kết), Focus (Tập trung), Openness (Cởi mở), Respect (Tôn trọng) và Courage (Dũng cảm). Những giá trị này là nền tảng văn hóa của Scrum.',
-     ARRAY['scrum-values'], '{}'::uuid[]),
+     ARRAY['scrum-values'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 27
     (q27, 'PSM-I',
      'What is the purpose of the Sprint Review?',
      'The Sprint Review''s purpose is to inspect the outcome of the Sprint and determine future adaptations. The Scrum Team presents the results to key stakeholders and discusses progress toward the Product Goal. The Product Backlog may be adjusted.',
      'Mục đích của Sprint Review là thanh tra kết quả của Sprint và xác định hướng thích nghi tiếp theo. Scrum Team trình bày kết quả cho các stakeholders chính và thảo luận về tiến độ hướng tới Product Goal.',
-     ARRAY['sprint-review', 'product-backlog'], '{}'::uuid[]),
+     ARRAY['sprint-review', 'product-backlog'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 28
     (q28, 'PSM-I',
      'What is the primary purpose of the Sprint Retrospective?',
      'The purpose of the Sprint Retrospective is to plan ways to increase quality and effectiveness. The Scrum Team inspects how the last Sprint went and identifies the most helpful improvements to implement next Sprint.',
      'Mục đích của Sprint Retrospective là lên kế hoạch cải thiện chất lượng và hiệu quả. Scrum Team kiểm tra Sprint vừa qua và xác định các cải tiến hữu ích nhất để áp dụng vào Sprint tiếp theo.',
-     ARRAY['sprint-retrospective'], '{}'::uuid[]),
+     ARRAY['sprint-retrospective'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 29
     (q29, 'PSM-I',
      'What does the Definition of Done provide for the Scrum Team?',
      'The Definition of Done creates transparency by providing everyone a shared understanding of what work is considered complete. If a Product Backlog item does not meet the DoD, it cannot be released or presented at the Sprint Review.',
      'Definition of Done tạo ra sự minh bạch bằng cách cung cấp hiểu biết chung về thế nào là "hoàn thành". Nếu một Product Backlog item không đáp ứng DoD, nó không thể phát hành hoặc trình bày tại Sprint Review.',
-     ARRAY['definition-of-done', 'transparency'], '{}'::uuid[]),
+     ARRAY['definition-of-done', 'transparency'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 30
     (q30, 'PSM-I',
      'Which statement best describes Scrum?',
      'Scrum is a lightweight framework that helps people, teams, and organizations generate value through adaptive solutions for complex problems. It is intentionally incomplete, only defining the parts required to implement Scrum theory.',
      'Scrum là một framework nhẹ giúp mọi người, nhóm và tổ chức tạo ra giá trị thông qua các giải pháp thích nghi cho các vấn đề phức tạp. Scrum cố tình không đầy đủ, chỉ định nghĩa những phần cần thiết.',
-     ARRAY['scrum', 'framework'], '{}'::uuid[]);
+     ARRAY['scrum', 'framework'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted');
 
   -- ────────────────────────────────────────────────────────────
   -- Options


### PR DESCRIPTION
- Replace .option-letter button with native radio (single) / checkbox (multi). Multi-select detected from correctCount > 1; auto-submits on N picks. Selected state uses primary border + bg, focus ring confined to input.
- Eliminate layout shift: hint becomes absolute popover, post-answer feedback
  + Next button live in a sticky bottom action bar, explanation moves to a slide-up sheet reusing .gloss-popup. Drop the selectionchange phrase bar (slider replacement planned for next iteration).
- Add `source` + `quality` columns to questions (migration 005), plus a quality chip on the quiz card. Drop the 3 self-generated sample questions from seed.sql and the live DB; tag the 30 Scrum Open Assessment questions as `trusted`.