### PR TITLE
N-gram phrase picker + colored option-mark chips

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -461,17 +461,28 @@ body {
 .option-mark {
   flex-shrink: 0;
   font-weight: 700;
-  font-size: 1rem;
+  font-size: 0.8rem;
+  width: 1.4rem;
+  height: 1.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1.5px solid currentColor;
+  line-height: 1;
 }
 
 .quiz-option.correct .option-mark {
   color: var(--success);
+  background: var(--success-light);
 }
 .quiz-option.incorrect .option-mark {
   color: var(--error);
+  background: var(--error-light);
 }
 .quiz-option.missed .option-mark {
   color: var(--success);
+  background: var(--success-light);
 }
 
 /* Hint shown only for multi-select questions */
@@ -1068,4 +1079,178 @@ progress::-webkit-progress-value {
   background: #e8eaf6;
   color: #3949ab;
   border-color: #c5cae9;
+}
+
+/* ========================
+   N-gram popup (tap-to-translate phrase picker)
+   ======================== */
+.ngram-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.ngram-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 0.85rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 0.92rem;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  color: var(--text);
+  transition:
+    background-color 0.15s,
+    border-color 0.15s;
+}
+
+.ngram-item:hover:not(:disabled) {
+  border-color: var(--primary);
+  background: var(--primary-light);
+}
+
+.ngram-item:disabled {
+  opacity: 0.5;
+  cursor: wait;
+}
+
+.ngram-item.has-term {
+  border-color: var(--success);
+  background: var(--success-light);
+  color: var(--success);
+  font-weight: 600;
+}
+
+.ngram-item-other {
+  background: transparent;
+  border-style: dashed;
+  color: var(--primary);
+  justify-content: center;
+}
+
+.ngram-text {
+  flex: 1;
+}
+
+.ngram-tag-glossary,
+.ngram-tag-ai {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.1rem 0.45rem;
+  border-radius: 20px;
+  white-space: nowrap;
+}
+
+.ngram-tag-glossary {
+  background: var(--success);
+  color: white;
+}
+
+.ngram-tag-ai {
+  background: #e8eaf6;
+  color: #3949ab;
+}
+
+/* Slider — drag to pick a phrase */
+.ngram-slider {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  padding: 0.5rem 0.25rem 0.75rem;
+  overflow-x: auto;
+  position: relative;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+  background: var(--bg);
+  border-radius: 8px;
+  margin-bottom: 0.75rem;
+}
+
+.ngram-notch {
+  flex: 0 0 auto;
+  min-width: 48px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.35rem;
+  cursor: grab;
+  position: relative;
+}
+
+.ngram-notch.out-of-segment {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.ngram-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--surface);
+  border: 2px solid var(--border);
+  transition:
+    background-color 0.1s,
+    border-color 0.1s,
+    transform 0.1s;
+}
+
+.ngram-notch.in-range .ngram-dot {
+  background: var(--primary);
+  border-color: var(--primary);
+}
+
+.ngram-notch.is-endpoint .ngram-dot {
+  width: 22px;
+  height: 22px;
+  background: var(--surface);
+  border-width: 4px;
+  border-color: var(--primary);
+  transform: translateY(-5px);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+}
+
+.ngram-label {
+  font-size: 0.82rem;
+  text-align: center;
+  word-break: keep-all;
+  color: var(--text-secondary);
+}
+
+.ngram-notch.in-range .ngram-label {
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.ngram-divider {
+  flex: 0 0 auto;
+  width: 1px;
+  background: var(--border);
+  margin: 0.4rem 0.35rem;
+}
+
+.ngram-preview {
+  margin: 0.25rem 0 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  word-break: break-word;
+}
+
+.ngram-preview strong {
+  color: var(--text);
+}
+
+.ngram-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
 }

--- a/src/lib/components/NgramPopup.svelte
+++ b/src/lib/components/NgramPopup.svelte
@@ -1,0 +1,238 @@
+<script lang="ts">
+  import { createEventDispatcher, onMount, tick } from 'svelte';
+  import {
+    suggestNgrams,
+    tokenizeWords,
+    lookupOrTranslate,
+    type NgramSuggestion,
+    type WordSpan,
+  } from '$lib/translate';
+
+  export let sentence: string;
+  export let charIdx: number;
+  export let ownerId: string;
+
+  const dispatch = createEventDispatcher<{ select: string; close: void }>();
+
+  type Phase = 'list' | 'slider';
+  let phase: Phase = 'list';
+  let suggestions: NgramSuggestion[] = [];
+  let loadingList = true;
+  let loadingTranslate = false;
+  let translateError = '';
+
+  // Slider state — initialized lazily when user opens the slider phase
+  let words: WordSpan[] = [];
+  let initialSegment = 0;
+  let leftIdx = 0;
+  let rightIdx = 0;
+  let dragOrigin: number | null = null;
+  let sliderEl: HTMLElement;
+
+  $: selectedPhrase =
+    words.length && leftIdx <= rightIdx
+      ? sentence.slice(words[leftIdx].start, words[rightIdx].end)
+      : '';
+
+  onMount(async () => {
+    suggestions = await suggestNgrams(sentence, charIdx, 4);
+    loadingList = false;
+  });
+
+  async function pickSuggestion(s: NgramSuggestion) {
+    if (s.termId) {
+      dispatch('select', s.termId);
+      return;
+    }
+    await translateAndSelect(s.text);
+  }
+
+  async function translateAndSelect(text: string) {
+    if (!text || loadingTranslate) return;
+    loadingTranslate = true;
+    translateError = '';
+    try {
+      const termId = await lookupOrTranslate(text, ownerId);
+      dispatch('select', termId);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      translateError = `Dịch thất bại: ${msg.slice(0, 120)}`;
+    } finally {
+      loadingTranslate = false;
+    }
+  }
+
+  async function openSlider() {
+    words = tokenizeWords(sentence);
+    const startIdx = words.findIndex((w) => w.start === charIdx);
+    if (startIdx >= 0) {
+      leftIdx = rightIdx = startIdx;
+      initialSegment = words[startIdx].segment;
+    } else {
+      leftIdx = rightIdx = 0;
+      initialSegment = words[0]?.segment ?? 0;
+    }
+    phase = 'slider';
+    await tick();
+  }
+
+  function backToList() {
+    phase = 'list';
+  }
+
+  function notchIndexFromX(clientX: number): number | null {
+    if (!sliderEl) return null;
+    const notches = sliderEl.querySelectorAll<HTMLElement>('.ngram-notch');
+    let bestIdx = -1;
+    let bestDist = Infinity;
+    for (let i = 0; i < notches.length; i++) {
+      const idx = parseInt(notches[i].dataset.index ?? '-1');
+      if (idx < 0 || words[idx]?.segment !== initialSegment) continue;
+      const r = notches[i].getBoundingClientRect();
+      const cx = r.left + r.width / 2;
+      const dist = Math.abs(clientX - cx);
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestIdx = idx;
+      }
+    }
+    return bestIdx >= 0 ? bestIdx : null;
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    const idx = notchIndexFromX(e.clientX);
+    if (idx === null) return;
+    e.preventDefault();
+    dragOrigin = idx;
+    leftIdx = rightIdx = idx;
+    try {
+      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    } catch {
+      // setPointerCapture may throw on some browsers if pointer already released
+    }
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (dragOrigin === null) return;
+    const idx = notchIndexFromX(e.clientX);
+    if (idx === null) return;
+    leftIdx = Math.min(dragOrigin, idx);
+    rightIdx = Math.max(dragOrigin, idx);
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    if (dragOrigin === null) return;
+    dragOrigin = null;
+    try {
+      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      // already released
+    }
+  }
+</script>
+
+<div class="gloss-overlay" on:click={() => dispatch('close')} role="presentation"></div>
+<div class="gloss-popup ngram-popup" role="dialog" aria-modal="true" aria-label="Chọn cụm từ">
+  <button class="gloss-close" on:click={() => dispatch('close')} aria-label="Đóng">✕</button>
+
+  {#if phase === 'list'}
+    <h3 style="margin:0 0 0.5rem;font-size:1rem">Chọn từ / cụm cần tra</h3>
+    {#if loadingList}
+      <div class="loading-spinner"></div>
+    {:else}
+      <ul class="ngram-list">
+        {#each suggestions as s}
+          <li>
+            <button
+              class="ngram-item"
+              class:has-term={!!s.termId}
+              on:click={() => pickSuggestion(s)}
+              disabled={loadingTranslate}
+            >
+              <span class="ngram-text">{s.text}</span>
+              {#if s.termId}
+                <span class="ngram-tag-glossary">📋 glossary</span>
+              {:else if s.length === 1}
+                <span class="ngram-tag-ai">🤖 dịch AI</span>
+              {/if}
+            </button>
+          </li>
+        {/each}
+        <li>
+          <button
+            class="ngram-item ngram-item-other"
+            on:click={openSlider}
+            disabled={loadingTranslate}
+          >
+            + Chọn cụm khác…
+          </button>
+        </li>
+      </ul>
+      {#if loadingTranslate}
+        <p class="text-secondary" style="font-size:0.85rem;margin-top:0.5rem">Đang dịch…</p>
+      {/if}
+      {#if translateError}
+        <p style="font-size:0.85rem;color:var(--error);margin-top:0.5rem">{translateError}</p>
+      {/if}
+    {/if}
+  {:else}
+    <h3 style="margin:0 0 0.25rem;font-size:1rem">Kéo để chọn cụm</h3>
+    <p class="text-secondary" style="font-size:0.78rem;margin-bottom:0.6rem">
+      Mỗi từ là một điểm; không vượt qua dấu câu.
+    </p>
+
+    <div
+      class="ngram-slider"
+      bind:this={sliderEl}
+      on:pointerdown={onPointerDown}
+      on:pointermove={onPointerMove}
+      on:pointerup={onPointerUp}
+      on:pointercancel={onPointerUp}
+      role="slider"
+      aria-valuemin={0}
+      aria-valuemax={Math.max(words.length - 1, 0)}
+      aria-valuenow={leftIdx}
+      tabindex="0"
+    >
+      {#each words as w, i (w.start)}
+        {@const inRange = i >= leftIdx && i <= rightIdx && w.segment === initialSegment}
+        {@const inSegment = w.segment === initialSegment}
+        {@const isEndpoint = (i === leftIdx || i === rightIdx) && inSegment}
+        <div
+          class="ngram-notch"
+          class:in-range={inRange}
+          class:is-endpoint={isEndpoint}
+          class:out-of-segment={!inSegment}
+          data-index={i}
+        >
+          <span class="ngram-dot"></span>
+          <span class="ngram-label">{w.text}</span>
+        </div>
+        {#if i < words.length - 1 && words[i + 1].segment !== w.segment}
+          <span class="ngram-divider" aria-hidden="true"></span>
+        {/if}
+      {/each}
+    </div>
+
+    <p class="ngram-preview">
+      Cụm: <strong>"{selectedPhrase}"</strong>
+    </p>
+
+    <div class="ngram-actions">
+      <button class="btn btn-ghost btn-sm" on:click={backToList} disabled={loadingTranslate}>
+        ← Quay lại
+      </button>
+      <button
+        class="btn btn-primary btn-sm"
+        on:click={() => translateAndSelect(selectedPhrase)}
+        disabled={loadingTranslate || !selectedPhrase}
+      >
+        {loadingTranslate ? 'Đang dịch…' : '🤖 Hỏi AI'}
+      </button>
+    </div>
+
+    {#if translateError}
+      <p style="font-size:0.85rem;color:var(--error);margin-top:0.5rem">{translateError}</p>
+    {/if}
+  {/if}
+</div>

--- a/src/lib/translate.ts
+++ b/src/lib/translate.ts
@@ -3,6 +3,41 @@ import { supabase } from './supabase';
 import { translateTerm } from './ai';
 import type { Term } from './types';
 
+// Punctuation that breaks a phrase: a slider/range cannot span across these.
+const PUNCT_BOUNDARY = /[.,;:!?]/;
+
+export interface WordSpan {
+  text: string;
+  start: number;
+  end: number;
+  /** Index of the punctuation-delimited segment this word belongs to. */
+  segment: number;
+}
+
+/**
+ * Splits a sentence into word spans with character offsets and segment ids.
+ * Words inside the same segment can be combined into a phrase; punctuation
+ * marks segment boundaries that the n-gram slider must never cross.
+ */
+export function tokenizeWords(sentence: string): WordSpan[] {
+  const out: WordSpan[] = [];
+  let segment = 0;
+  let i = 0;
+  while (i < sentence.length) {
+    const ch = sentence[i];
+    if (isLetter(ch)) {
+      let j = i + 1;
+      while (j < sentence.length && isLetter(sentence[j])) j++;
+      out.push({ text: sentence.slice(i, j), start: i, end: j, segment });
+      i = j;
+    } else {
+      if (PUNCT_BOUNDARY.test(ch)) segment++;
+      i++;
+    }
+  }
+  return out;
+}
+
 /**
  * Tokenizes a text stem into clickable HTML spans.
  *
@@ -11,6 +46,9 @@ import type { Term } from './types';
  *      Multi-word phrases ("Product Owner") are matched before their parts.
  *   2. Remaining letter sequences become `.any-word` spans (AI-translatable).
  *   3. Non-letter characters (spaces, punctuation) are emitted as plain text.
+ *
+ * Each interactive span carries `data-char-idx` (start offset in the original
+ * sentence) so callers can derive the n-gram window for the slider popup.
  */
 export function tokenizeStem(stem: string, knownTerms: Term[]): string {
   const sorted = [...knownTerms].sort((a, b) => b.text.length - a.text.length);
@@ -30,7 +68,7 @@ export function tokenizeStem(stem: string, knownTerms: Term[]): string {
       if (before && after) {
         const raw = stem.slice(i, i + t.length);
         out.push(
-          `<span class="glossary-term" data-term-id="${term.id}" tabindex="0" role="button">${escHtml(raw)}</span>`
+          `<span class="glossary-term" data-term-id="${term.id}" data-char-idx="${i}" tabindex="0" role="button">${escHtml(raw)}</span>`
         );
         i += t.length;
         matched = true;
@@ -46,7 +84,7 @@ export function tokenizeStem(stem: string, knownTerms: Term[]): string {
       const word = stem.slice(i, j);
       if (word.length >= 2) {
         out.push(
-          `<span class="any-word" data-word="${escAttr(word)}" tabindex="0" role="button">${escHtml(word)}</span>`
+          `<span class="any-word" data-word="${escAttr(word)}" data-char-idx="${i}" tabindex="0" role="button">${escHtml(word)}</span>`
         );
       } else {
         out.push(escHtml(word));
@@ -59,6 +97,49 @@ export function tokenizeStem(stem: string, knownTerms: Term[]): string {
   }
 
   return out.join('');
+}
+
+export interface NgramSuggestion {
+  text: string;
+  /** Existing term id if this n-gram is in the glossary, else null. */
+  termId: string | null;
+  length: number;
+}
+
+/**
+ * Returns n-gram suggestions starting at the clicked word.
+ *
+ * - Always includes the clicked word as the 1-gram (even if not in glossary).
+ * - Includes 2..maxLen grams ONLY if they exist in the glossary.
+ * - Stops at the next punctuation boundary (the n-gram never spans across).
+ * - Sorted by length ASC, matching the UX described in chat:
+ *   "item đầu tiên là từ đó, item thứ 2 là cụm từ có thể có..."
+ */
+export async function suggestNgrams(
+  sentence: string,
+  charIdx: number,
+  maxLen = 4
+): Promise<NgramSuggestion[]> {
+  const words = tokenizeWords(sentence);
+  const startIdx = words.findIndex((w) => w.start === charIdx);
+  if (startIdx === -1) return [];
+
+  const segment = words[startIdx].segment;
+  const window: WordSpan[] = [];
+  for (let i = startIdx; i < words.length && window.length < maxLen; i++) {
+    if (words[i].segment !== segment) break;
+    window.push(words[i]);
+  }
+
+  const results: NgramSuggestion[] = [];
+  for (let n = 1; n <= window.length; n++) {
+    const text = sentence.slice(window[0].start, window[n - 1].end);
+    const term = await db.terms.filter((t) => t.text.toLowerCase() === text.toLowerCase()).first();
+    if (term || n === 1) {
+      results.push({ text, termId: term?.id ?? null, length: n });
+    }
+  }
+  return results;
 }
 
 /**

--- a/src/routes/quiz/+page.svelte
+++ b/src/routes/quiz/+page.svelte
@@ -5,9 +5,10 @@
   import { improveProgress, canPractice, shuffleByIndex, getBadge } from '$lib/srs';
   import { sessionLookups } from '$lib/stores/session';
   import { authUser } from '$lib/stores/auth';
-  import { tokenizeStem, lookupOrTranslate } from '$lib/translate';
+  import { tokenizeStem } from '$lib/translate';
   import type { Question, QuestionOption, Term } from '$lib/types';
   import TermPopup from '$lib/components/TermPopup.svelte';
+  import NgramPopup from '$lib/components/NgramPopup.svelte';
 
   type ExamFilter = 'all' | 'PSM-I' | 'PSPO-I';
   const EXAM_FILTERS: ExamFilter[] = ['all', 'PSM-I', 'PSPO-I'];
@@ -33,8 +34,8 @@
   let highlightedStem = '';
   let selectedTermId: string | null = null;
   let allTermsForTokenize: Term[] = [];
-  let translatingWord: string | null = null;
-  let translateError: string | null = null;
+  let ngramSentence: string | null = null;
+  let ngramCharIdx = 0;
 
   $: currentUserId = $authUser?.id;
   $: currentQ = sessionQuestions[sessionIndex] ?? null;
@@ -118,34 +119,37 @@
     highlightedStem = tokenizeStem(q.stem, allTermsForTokenize);
   }
 
-  async function handleStemInteraction(e: MouseEvent | KeyboardEvent) {
+  function handleStemInteraction(e: MouseEvent | KeyboardEvent) {
     if (e instanceof KeyboardEvent && e.key !== 'Enter' && e.key !== ' ') return;
 
-    const termEl = (e.target as HTMLElement).closest<HTMLElement>('[data-term-id]');
+    const target = e.target as HTMLElement;
+    const termEl = target.closest<HTMLElement>('[data-term-id]');
+    const wordEl = target.closest<HTMLElement>('[data-word]');
+    if (!termEl && !wordEl) return;
+
+    // Stop the click from reaching the surrounding <label>, which would
+    // otherwise toggle the answer's radio/checkbox.
+    e.preventDefault();
+    e.stopPropagation();
+
+    // Glossary term → open its detail popup directly (skip n-gram picker)
     if (termEl?.dataset.termId) {
       selectedTermId = termEl.dataset.termId;
       return;
     }
 
-    if (!currentUserId || translatingWord) return;
-    const wordEl = (e.target as HTMLElement).closest<HTMLElement>('[data-word]');
-    if (!wordEl?.dataset.word) return;
+    if (!currentUserId || !wordEl) return;
+    const sentenceEl = wordEl.closest<HTMLElement>('[data-sentence]');
+    const sentence = sentenceEl?.dataset.sentence ?? wordEl.dataset.word ?? '';
+    const charIdx = parseInt(wordEl.dataset.charIdx ?? '0', 10);
+    ngramSentence = sentence;
+    ngramCharIdx = charIdx;
+  }
 
-    const word = wordEl.dataset.word;
-    translatingWord = word;
-    translateError = null;
-    try {
-      const termId = await lookupOrTranslate(word, currentUserId);
-      allTermsForTokenize = await db.terms.toArray();
-      selectedTermId = termId;
-    } catch (err) {
-      console.error('Translation failed:', err);
-      const msg = err instanceof Error ? err.message : String(err);
-      translateError = `Dịch thất bại: ${msg.slice(0, 120)}`;
-      setTimeout(() => (translateError = null), 6000);
-    } finally {
-      translatingWord = null;
-    }
+  async function onNgramSelect(termId: string) {
+    ngramSentence = null;
+    allTermsForTokenize = await db.terms.toArray();
+    selectedTermId = termId;
   }
 
   async function toggleOption(opt: QuestionOption) {
@@ -341,6 +345,7 @@
     <!-- Question stem -->
     <div
       class="question-stem"
+      data-sentence={currentQ.stem}
       on:click={handleStemInteraction}
       on:keydown={handleStemInteraction}
       role="presentation"
@@ -348,12 +353,7 @@
       {@html highlightedStem}
     </div>
 
-    <p class="glossary-hint-label">
-      💡 Click từ trong câu để tra nghĩa
-      {#if translatingWord}<span class="translate-loading">· Đang dịch "{translatingWord}"…</span
-        >{/if}
-      {#if translateError}<span class="translate-error">· {translateError}</span>{/if}
-    </p>
+    <p class="glossary-hint-label">💡 Click từ trong câu để tra nghĩa hoặc chọn cụm</p>
 
     <!-- Multi-select hint -->
     {#if isMulti}
@@ -375,7 +375,13 @@
             on:change={() => toggleOption(opt)}
           />
           <span class="option-letter-label">{String.fromCharCode(65 + i)}</span>
-          <span class="option-text">{@html optionStems[i] ?? opt.text}</span>
+          <span
+            class="option-text"
+            data-sentence={opt.text}
+            on:click={handleStemInteraction}
+            on:keydown={handleStemInteraction}
+            role="presentation">{@html optionStems[i] ?? opt.text}</span
+          >
           {#if answered}
             <span class="option-mark">
               {#if opt.correct}✓{:else if selectedIds.has(opt.id)}✗{/if}
@@ -472,6 +478,17 @@
       {/if}
     </div>
   {/if}
+{/if}
+
+<!-- N-gram phrase picker (opens on plain-word tap) -->
+{#if ngramSentence && currentUserId}
+  <NgramPopup
+    sentence={ngramSentence}
+    charIdx={ngramCharIdx}
+    ownerId={currentUserId}
+    on:select={(e) => onNgramSelect(e.detail)}
+    on:close={() => (ngramSentence = null)}
+  />
 {/if}
 
 <!-- Term detail popup -->


### PR DESCRIPTION
Click a non-glossary word in a quiz stem or option to open NgramPopup, which lists 1..maxLen=4 grams starting at that word — the 1-gram is always present (sends the click straight to AI translate if no glossary hit), longer n-grams appear only when they exist in the glossary, sorted ASC by length. The list ends with "Chọn cụm khác…" which opens a slider view: each word is a notch on a track, two endpoint dots define the range, drag selects, and the segment containing the originally clicked word acts as a hard boundary (punctuation = boundary). Glossary terms still open TermPopup directly so the explicit-phrase flow is unchanged.

`tokenizeStem` now annotates every interactive span with `data-char-idx` and option/stem wrappers carry `data-sentence`, giving the popup the context it needs to compute n-grams. Word-click events stop propagation so they don't bubble to the surrounding `<label>` and toggle the answer.

Also round out the post-answer marks (✓/✗) as filled circular chips so the correctness color is visible at a glance instead of just on the glyph stroke.