### PR TITLE
Fix translation failure + answer-word clicks, polish slider

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -1,0 +1,49 @@
+name: Deploy Supabase Edge Functions
+
+on:
+  # Auto-deploy when the function code changes on main
+  push:
+    branches: [master, main]
+    paths:
+      - 'supabase/functions/**'
+      - '.github/workflows/deploy-functions.yml'
+  # Manual deploy from any branch — useful when testing changes from a PR
+  # branch before merging. Run via Actions → Deploy Supabase Edge Functions
+  # → Run workflow → pick branch.
+  workflow_dispatch:
+    inputs:
+      sync-secrets:
+        description: 'Also sync OPENROUTER_API_KEY (only needed when the secret rotated)'
+        type: boolean
+        default: false
+
+concurrency:
+  group: deploy-functions
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Deploy openrouter function
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: |
+          supabase functions deploy openrouter \
+            --no-verify-jwt \
+            --project-ref ${{ secrets.SUPABASE_PROJECT_ID }}
+
+      - name: Sync OPENROUTER_API_KEY secret
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.sync-secrets }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          supabase secrets set OPENROUTER_API_KEY="$OPENROUTER_API_KEY" \
+            --project-ref ${{ secrets.SUPABASE_PROJECT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,29 +54,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-
-  deploy-functions:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: supabase/setup-cli@v1
-        with:
-          version: latest
-
-      - name: Deploy edge functions
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-        run: |
-          supabase functions deploy openrouter \
-            --no-verify-jwt \
-            --project-ref ${{ secrets.SUPABASE_PROJECT_ID }}
-
-      - name: Sync secrets
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-        run: |
-          supabase secrets set OPENROUTER_API_KEY="$OPENROUTER_API_KEY" \
-            --project-ref ${{ secrets.SUPABASE_PROJECT_ID }}

--- a/src/app.css
+++ b/src/app.css
@@ -404,24 +404,63 @@ body {
   color: var(--success);
 }
 
-/* Native input — focus ring confined to it only */
-.option-input {
+/* Custom radio/checkbox visual — replaces a native input so click handling
+   on word spans inside the option stays in our control. */
+.option-input-visual {
   flex-shrink: 0;
-  width: 1.15rem;
-  height: 1.15rem;
-  margin: 0;
-  cursor: pointer;
-  accent-color: var(--primary);
+  width: 1.2rem;
+  height: 1.2rem;
+  border: 2px solid var(--border);
+  border-radius: 50%;
+  background: var(--surface);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  transition:
+    background-color 0.1s,
+    border-color 0.1s;
 }
 
-.option-input:focus-visible {
-  outline: 2px solid var(--primary);
-  outline-offset: 2px;
+.option-input-visual.multi {
   border-radius: 4px;
 }
 
-.option-input:disabled {
-  cursor: default;
+.quiz-option[aria-checked='true'] .option-input-visual {
+  background: var(--primary);
+  border-color: var(--primary);
+}
+
+.quiz-option.correct .option-input-visual,
+.quiz-option.missed .option-input-visual {
+  background: var(--success);
+  border-color: var(--success);
+}
+
+.quiz-option.incorrect .option-input-visual {
+  background: var(--error);
+  border-color: var(--error);
+}
+
+.quiz-option:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.quiz-option:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.radio-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.check-tick {
+  width: 0.85rem;
+  height: 0.85rem;
 }
 
 /* A/B/C/D letter — visual aid only, not interactive */
@@ -1167,7 +1206,9 @@ progress::-webkit-progress-value {
   padding: 0.5rem 0.25rem 0.75rem;
   overflow-x: auto;
   position: relative;
-  touch-action: none;
+  /* Container allows horizontal panning for long sentences; individual notches
+     opt out so drag-select wins over scroll when the user starts on a notch. */
+  touch-action: pan-x;
   user-select: none;
   -webkit-user-select: none;
   background: var(--bg);
@@ -1175,16 +1216,22 @@ progress::-webkit-progress-value {
   margin-bottom: 0.75rem;
 }
 
+.ngram-slider:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
 .ngram-notch {
   flex: 0 0 auto;
-  min-width: 48px;
+  min-width: 36px;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 0.4rem;
-  padding: 0.4rem 0.35rem;
+  padding: 0.4rem 0.3rem;
   cursor: grab;
   position: relative;
+  touch-action: none;
 }
 
 .ngram-notch.out-of-segment {

--- a/src/app.css
+++ b/src/app.css
@@ -863,13 +863,17 @@ progress::-webkit-progress-value {
   text-decoration-color: var(--primary);
   text-underline-offset: 3px;
   cursor: pointer;
-  border-radius: 3px;
-  padding: 0 1px;
+  border-radius: 4px;
+  /* Enlarged hit area so taps on phones land reliably even at line edges. */
+  padding: 0.15em 0.2em;
+  margin: 0 -0.05em;
   transition: background 0.15s;
 }
 
-.glossary-term:hover {
+.glossary-term:hover,
+.glossary-term:focus-visible {
   background: var(--primary-light);
+  outline: none;
 }
 
 /* Question stem */
@@ -1083,12 +1087,25 @@ progress::-webkit-progress-value {
   text-decoration-color: #b0bec5;
   text-underline-offset: 3px;
   cursor: pointer;
-  border-radius: 2px;
+  border-radius: 3px;
+  /* Enlarged hit area so a tap that lands a few pixels off still hits the
+     word instead of falling through to the answer option's toggle. */
+  padding: 0.15em 0.15em;
+  margin: 0 -0.05em;
   transition: background 0.15s;
 }
 
-.any-word:hover {
+.any-word:hover,
+.any-word:focus-visible {
   background: #eceff1;
+  outline: none;
+}
+
+/* Stem/options need slightly looser line-height to absorb the extra hit-area
+   padding on words without rows colliding. */
+.question-stem,
+.option-text {
+  line-height: 1.85;
 }
 
 /* Inline loading indicator while AI translates */

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -10,19 +10,30 @@ const SYSTEM_PROMPT = `You are a Vietnamese-English expert specializing in Scrum
 Given a word or phrase (typically from a Scrum context), respond with JSON only — no markdown fences:
 {"en": "<concise English definition, 1-2 sentences>", "vi": "<Vietnamese translation/explanation, 1-2 sentences>", "note": "<optional usage tip in Vietnamese, or empty string>"}`;
 
-export async function translateTerm(word: string): Promise<TranslateResult> {
-  try {
-    return await callModel('google/gemini-2.0-flash-exp:free', word);
-  } catch {
-    // Rate-limit or error on free model — fall back to cheap paid model
-    return await callModel('google/gemini-flash-1.5-8b', word);
-  }
+// Tried in order server-side. Free models first, paid 8b as last resort.
+const MODELS = [
+  'google/gemini-2.0-flash-exp:free',
+  'meta-llama/llama-3.3-70b-instruct:free',
+  'google/gemma-2-9b-it:free',
+  'google/gemini-flash-1.5-8b',
+];
+
+interface OpenRouterChoice {
+  message?: { content?: string };
+}
+interface OpenRouterResponse {
+  choices?: OpenRouterChoice[];
+}
+interface ProxyEnvelope {
+  data?: OpenRouterResponse;
+  model?: string;
+  errors?: string[];
 }
 
-async function callModel(model: string, word: string): Promise<TranslateResult> {
-  const { data, error } = await supabase.functions.invoke('openrouter', {
+export async function translateTerm(word: string): Promise<TranslateResult> {
+  const { data, error } = await supabase.functions.invoke<ProxyEnvelope>('openrouter', {
     body: {
-      model,
+      models: MODELS,
       messages: [
         { role: 'system', content: SYSTEM_PROMPT },
         { role: 'user', content: `Translate: "${word}"` },
@@ -31,12 +42,13 @@ async function callModel(model: string, word: string): Promise<TranslateResult> 
     },
   });
 
-  if (error) throw new Error(error.message);
-  if (data?.error) throw new Error(String(data.error?.message ?? data.error));
+  if (error) throw new Error(`Edge function not reachable: ${error.message}`);
+  if (!data) throw new Error('Edge function returned empty response');
+  if (data.errors?.length) throw new Error(data.errors.join(' | '));
 
-  const content: string = data?.choices?.[0]?.message?.content ?? '';
+  const content: string = data.data?.choices?.[0]?.message?.content ?? '';
   try {
-    const parsed = JSON.parse(content.trim());
+    const parsed = JSON.parse(content.trim()) as Partial<TranslateResult>;
     return {
       en: String(parsed.en ?? word),
       vi: String(parsed.vi ?? word),

--- a/src/lib/components/NgramPopup.svelte
+++ b/src/lib/components/NgramPopup.svelte
@@ -129,6 +129,49 @@
       // already released
     }
   }
+
+  function segmentBounds(): { first: number; last: number } | null {
+    let first = -1;
+    let last = -1;
+    for (let i = 0; i < words.length; i++) {
+      if (words[i].segment !== initialSegment) continue;
+      if (first === -1) first = i;
+      last = i;
+    }
+    return first === -1 ? null : { first, last };
+  }
+
+  function onSliderKey(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      translateAndSelect(selectedPhrase);
+      return;
+    }
+    const bounds = segmentBounds();
+    if (!bounds) return;
+
+    const moveEnd = e.shiftKey ? 'left' : 'right';
+    const apply = (delta: number) => {
+      e.preventDefault();
+      if (moveEnd === 'right') {
+        rightIdx = Math.min(bounds.last, Math.max(leftIdx, rightIdx + delta));
+      } else {
+        leftIdx = Math.max(bounds.first, Math.min(rightIdx, leftIdx + delta));
+      }
+    };
+
+    if (e.key === 'ArrowRight') apply(1);
+    else if (e.key === 'ArrowLeft') apply(-1);
+    else if (e.key === 'Home') {
+      e.preventDefault();
+      if (moveEnd === 'right') rightIdx = leftIdx;
+      else leftIdx = bounds.first;
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      if (moveEnd === 'right') rightIdx = bounds.last;
+      else leftIdx = rightIdx;
+    }
+  }
 </script>
 
 <div class="gloss-overlay" on:click={() => dispatch('close')} role="presentation"></div>
@@ -178,7 +221,8 @@
   {:else}
     <h3 style="margin:0 0 0.25rem;font-size:1rem">Kéo để chọn cụm</h3>
     <p class="text-secondary" style="font-size:0.78rem;margin-bottom:0.6rem">
-      Mỗi từ là một điểm; không vượt qua dấu câu.
+      Mỗi từ là một điểm; không vượt qua dấu câu. Bàn phím: ←/→ chỉnh đầu phải, Shift+←/→ chỉnh đầu
+      trái, Enter để dịch.
     </p>
 
     <div
@@ -188,10 +232,12 @@
       on:pointermove={onPointerMove}
       on:pointerup={onPointerUp}
       on:pointercancel={onPointerUp}
+      on:keydown={onSliderKey}
       role="slider"
       aria-valuemin={0}
       aria-valuemax={Math.max(words.length - 1, 0)}
       aria-valuenow={leftIdx}
+      aria-valuetext={selectedPhrase}
       tabindex="0"
     >
       {#each words as w, i (w.start)}

--- a/src/lib/components/TermPopup.svelte
+++ b/src/lib/components/TermPopup.svelte
@@ -8,8 +8,10 @@
   import { improveProgress, canPractice, getBadge } from '$lib/srs';
 
   export let termId: string | null = null;
+  /** When true, show a "Chọn cụm khác…" link that lets the parent open the slider. */
+  export let canPickPhrase = false;
 
-  const dispatch = createEventDispatcher<{ close: void }>();
+  const dispatch = createEventDispatcher<{ close: void; pickPhrase: void }>();
 
   let term: Term | null = null;
   let senses: TermSense[] = [];
@@ -105,6 +107,16 @@
         <p class="text-secondary mt-2" style="font-size:0.85rem;text-align:center">
           Ôn lại vào {new Date(progress.nextReview).toLocaleDateString('vi-VN')}
         </p>
+      {/if}
+
+      {#if canPickPhrase}
+        <button
+          class="btn btn-ghost btn-sm mt-2"
+          on:click={() => dispatch('pickPhrase')}
+          style="width:100%"
+        >
+          ✂ Chọn cụm khác trong câu…
+        </button>
       {/if}
     {/if}
   </div>

--- a/src/routes/quiz/+page.svelte
+++ b/src/routes/quiz/+page.svelte
@@ -36,6 +36,8 @@
   let allTermsForTokenize: Term[] = [];
   let ngramSentence: string | null = null;
   let ngramCharIdx = 0;
+  let lastClickedSentence = '';
+  let lastClickedCharIdx = 0;
 
   $: currentUserId = $authUser?.id;
   $: currentQ = sessionQuestions[sessionIndex] ?? null;
@@ -119,37 +121,60 @@
     highlightedStem = tokenizeStem(q.stem, allTermsForTokenize);
   }
 
-  function handleStemInteraction(e: MouseEvent | KeyboardEvent) {
-    if (e instanceof KeyboardEvent && e.key !== 'Enter' && e.key !== ' ') return;
-
+  function handleStemInteraction(e: MouseEvent | KeyboardEvent): boolean {
+    if (e instanceof KeyboardEvent && e.key !== 'Enter' && e.key !== ' ') return false;
     const target = e.target as HTMLElement;
     const termEl = target.closest<HTMLElement>('[data-term-id]');
     const wordEl = target.closest<HTMLElement>('[data-word]');
-    if (!termEl && !wordEl) return;
-
-    // Stop the click from reaching the surrounding <label>, which would
-    // otherwise toggle the answer's radio/checkbox.
+    if (!termEl && !wordEl) return false;
     e.preventDefault();
     e.stopPropagation();
+    openWordOrTerm(termEl, wordEl);
+    return true;
+  }
 
-    // Glossary term → open its detail popup directly (skip n-gram picker)
+  function openWordOrTerm(termEl: HTMLElement | null, wordEl: HTMLElement | null) {
     if (termEl?.dataset.termId) {
+      // Glossary term → remember context (so TermPopup can offer "Chọn cụm khác…")
+      const sEl = termEl.closest<HTMLElement>('[data-sentence]');
+      lastClickedSentence = sEl?.dataset.sentence ?? '';
+      lastClickedCharIdx = parseInt(termEl.dataset.charIdx ?? '0', 10);
       selectedTermId = termEl.dataset.termId;
       return;
     }
-
     if (!currentUserId || !wordEl) return;
     const sentenceEl = wordEl.closest<HTMLElement>('[data-sentence]');
     const sentence = sentenceEl?.dataset.sentence ?? wordEl.dataset.word ?? '';
     const charIdx = parseInt(wordEl.dataset.charIdx ?? '0', 10);
+    lastClickedSentence = sentence;
+    lastClickedCharIdx = charIdx;
     ngramSentence = sentence;
     ngramCharIdx = charIdx;
+  }
+
+  function handleOptionInteraction(e: MouseEvent | KeyboardEvent, opt: QuestionOption) {
+    // Words/terms always win over the option toggle so the user can tap a word
+    // inside an answer to translate it instead of accidentally picking that answer.
+    if (handleStemInteraction(e)) return;
+    if (e instanceof KeyboardEvent) {
+      if (e.key !== 'Enter' && e.key !== ' ') return;
+      e.preventDefault();
+    }
+    if (answered) return;
+    toggleOption(opt);
   }
 
   async function onNgramSelect(termId: string) {
     ngramSentence = null;
     allTermsForTokenize = await db.terms.toArray();
     selectedTermId = termId;
+  }
+
+  function openSliderFromTerm() {
+    if (!lastClickedSentence) return;
+    selectedTermId = null;
+    ngramSentence = lastClickedSentence;
+    ngramCharIdx = lastClickedCharIdx;
   }
 
   async function toggleOption(opt: QuestionOption) {
@@ -363,31 +388,46 @@
     {/if}
 
     <!-- Answer options -->
-    <div class="quiz-options">
+    <div class="quiz-options" role={isMulti ? 'group' : 'radiogroup'}>
       {#each options as opt, i}
-        <label class="quiz-option {optionClass(opt)}" class:disabled={answered}>
-          <input
-            type={isMulti ? 'checkbox' : 'radio'}
-            name="quiz-answer-{currentQ.id}"
-            class="option-input"
-            checked={selectedIds.has(opt.id)}
-            disabled={answered}
-            on:change={() => toggleOption(opt)}
-          />
+        <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+        <div
+          class="quiz-option {optionClass(opt)}"
+          class:disabled={answered}
+          role={isMulti ? 'checkbox' : 'radio'}
+          aria-checked={selectedIds.has(opt.id)}
+          aria-disabled={answered}
+          tabindex={answered ? -1 : 0}
+          data-sentence={opt.text}
+          on:click={(e) => handleOptionInteraction(e, opt)}
+          on:keydown={(e) => handleOptionInteraction(e, opt)}
+        >
+          <span class="option-input-visual" class:multi={isMulti}>
+            {#if selectedIds.has(opt.id)}
+              {#if isMulti}
+                <svg viewBox="0 0 16 16" class="check-tick" aria-hidden="true">
+                  <path
+                    d="M3 8.5l3 3 6.5-7"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              {:else}
+                <span class="radio-dot"></span>
+              {/if}
+            {/if}
+          </span>
           <span class="option-letter-label">{String.fromCharCode(65 + i)}</span>
-          <span
-            class="option-text"
-            data-sentence={opt.text}
-            on:click={handleStemInteraction}
-            on:keydown={handleStemInteraction}
-            role="presentation">{@html optionStems[i] ?? opt.text}</span
-          >
+          <span class="option-text">{@html optionStems[i] ?? opt.text}</span>
           {#if answered}
             <span class="option-mark">
               {#if opt.correct}✓{:else if selectedIds.has(opt.id)}✗{/if}
             </span>
           {/if}
-        </label>
+        </div>
       {/each}
     </div>
 
@@ -492,4 +532,12 @@
 {/if}
 
 <!-- Term detail popup -->
-<TermPopup termId={selectedTermId} on:close={() => (selectedTermId = null)} />
+<TermPopup
+  termId={selectedTermId}
+  canPickPhrase={!!lastClickedSentence && !!currentUserId}
+  on:close={() => {
+    selectedTermId = null;
+    lastClickedSentence = '';
+  }}
+  on:pickPhrase={openSliderFromTerm}
+/>

--- a/src/routes/quiz/+page.svelte
+++ b/src/routes/quiz/+page.svelte
@@ -156,6 +156,9 @@
     // Words/terms always win over the option toggle so the user can tap a word
     // inside an answer to translate it instead of accidentally picking that answer.
     if (handleStemInteraction(e)) return;
+    // While a popup is open the user is interacting with the popup, not the
+    // option — drop any straggler keyboard events that bubbled through.
+    if (ngramSentence || selectedTermId) return;
     if (e instanceof KeyboardEvent) {
       if (e.key !== 'Enter' && e.key !== ' ') return;
       e.preventDefault();

--- a/supabase/functions/openrouter/index.ts
+++ b/supabase/functions/openrouter/index.ts
@@ -2,13 +2,19 @@
  * Supabase Edge Function — OpenRouter proxy
  *
  * Keeps the OPENROUTER_API_KEY server-side.
- * Client sends: { model, messages, max_tokens? }
- * This function forwards to OpenRouter and streams/returns the response.
+ * Client sends: { models?: string[], model?: string, messages, max_tokens? }
+ * - `models` (preferred): list of model ids tried in order; first 2xx wins.
+ * - `model` (legacy): single model id, equivalent to `models: [model]`.
+ *
+ * Always returns a 200 with `{ data?, model?, errors? }`. The proxy never
+ * forwards OpenRouter's non-2xx status, because supabase-js v2 treats
+ * non-2xx as an opaque "Failed to send a request" error that hides the
+ * upstream message.
  *
  * Deploy:
  *   supabase functions deploy openrouter --no-verify-jwt
  *
- * Set secret (from GitHub Actions or CLI):
+ * Set secret:
  *   supabase secrets set OPENROUTER_API_KEY=sk-or-...
  */
 
@@ -23,26 +29,29 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
 };
 
+const DEFAULT_FALLBACK_MODELS = [
+  'google/gemini-2.0-flash-exp:free',
+  'meta-llama/llama-3.3-70b-instruct:free',
+  'google/gemma-2-9b-it:free',
+];
+
 serve(async (req: Request) => {
-  // CORS preflight
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }
 
   if (req.method !== 'POST') {
-    return new Response('Method not allowed', { status: 405, headers: corsHeaders });
+    return json({ errors: ['Method not allowed'] }, 200);
   }
 
   const apiKey = Deno.env.get('OPENROUTER_API_KEY');
   if (!apiKey) {
-    return new Response(
-      JSON.stringify({ error: 'OPENROUTER_API_KEY not configured' }),
-      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-    );
+    return json({ errors: ['OPENROUTER_API_KEY not configured on edge function'] }, 200);
   }
 
   let body: {
     model?: string;
+    models?: string[];
     messages: Array<{ role: string; content: string }>;
     max_tokens?: number;
   };
@@ -50,35 +59,63 @@ serve(async (req: Request) => {
   try {
     body = await req.json();
   } catch {
-    return new Response(
-      JSON.stringify({ error: 'Invalid JSON body' }),
-      { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-    );
+    return json({ errors: ['Invalid JSON body'] }, 200);
   }
 
-  // Default to a capable free multilingual model (good Vietnamese + domain terms).
-  // Swap this single line to try another model, e.g. 'openai/gpt-oss-20b:free'.
-  const model = body.model ?? 'google/gemini-2.0-flash-exp:free';
+  const candidates =
+    (Array.isArray(body.models) && body.models.length ? body.models : null) ??
+    (body.model ? [body.model] : DEFAULT_FALLBACK_MODELS);
 
-  const response = await fetch(OPENROUTER_URL, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      'Content-Type': 'application/json',
-      'HTTP-Referer': Deno.env.get('SITE_URL') ?? 'https://tuongna.github.io',
-      'X-Title': 'KfR Scrum Learning',
-    },
-    body: JSON.stringify({
-      model,
-      messages: body.messages,
-      max_tokens: body.max_tokens ?? 512,
-    }),
-  });
+  const errors: string[] = [];
 
-  const data = await response.json();
+  for (const model of candidates) {
+    try {
+      const response = await fetch(OPENROUTER_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+          'HTTP-Referer': Deno.env.get('SITE_URL') ?? 'https://tuongna.github.io',
+          'X-Title': 'KfR Scrum Learning',
+        },
+        body: JSON.stringify({
+          model,
+          messages: body.messages,
+          max_tokens: body.max_tokens ?? 512,
+        }),
+      });
 
-  return new Response(JSON.stringify(data), {
-    status: response.status,
+      const raw = await response.text();
+      let parsed: unknown = null;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        // OpenRouter is expected to always return JSON
+      }
+
+      if (!response.ok) {
+        const msg =
+          (parsed &&
+            typeof parsed === 'object' &&
+            (parsed as { error?: { message?: string } }).error?.message) ||
+          raw.slice(0, 200) ||
+          `HTTP ${response.status}`;
+        errors.push(`${model}: ${msg}`);
+        continue;
+      }
+
+      return json({ data: parsed, model }, 200);
+    } catch (e) {
+      errors.push(`${model}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  return json({ errors }, 200);
+});
+
+function json(payload: unknown, status: number) {
+  return new Response(JSON.stringify(payload), {
+    status,
     headers: { ...corsHeaders, 'Content-Type': 'application/json' },
   });
-});
+}


### PR DESCRIPTION
- Edge function now accepts a `models` array and tries each in order, returning the first successful response wrapped in `{ data, model }`. Non-2xx upstream responses are mapped to `{ errors: [...] }` at HTTP 200 so supabase-js doesn't collapse them into "Failed to send a request to the Edge Function". Client sends the fallback chain (gemini-2.0-flash-exp:free → llama-3.3-70b:free → gemma-2-9b:free → gemini-flash-1.5-8b) on every translate call.
- Replace `<label>` + native `<input>` with a `<div role="radio|checkbox">` so word clicks inside an option no longer leak through to the label/input default action and silently toggle the answer. The custom visual mirrors the prior radio/checkbox and inherits answered-state colors. handleStemInteraction returns a bool the option handler uses to decide whether the click was for a word or for the answer itself.
- N-gram slider: notches now use `touch-action: none` while the container uses `pan-x` so long sentences scroll horizontally while on-notch drags still capture the pointer. Notch min-width down to 36px. Keyboard support added: ←/→ moves the right endpoint, Shift+←/→ the left, Home/End jump to segment edges, Enter triggers translation.
- TermPopup now has an optional "Chọn cụm khác trong câu…" button. Quiz page tracks the sentence + char index of the most recent word click and passes it through so the user can drop into the slider even after landing on a glossary phrase. Clearing the click context on TermPopup close prevents stale sentences leaking into tag clicks from the results screen or explanation sheet.