### PR TITLE
Allow required CORS headers and recommend restricting ALLOWED_ORIGINS

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -48,6 +48,8 @@ supabase link --project-ref YOUR_PROJECT_REF
 # Set secret (lấy từ GitHub Secret hoặc trực tiếp)
 supabase secrets set OPENROUTER_API_KEY=sk-or-...
 supabase secrets set SITE_URL=https://tuongna.github.io
+# Production: không dùng '*', chỉ cho phép đúng domain frontend
+supabase secrets set ALLOWED_ORIGINS=https://tuongna.github.io
 
 # Deploy function
 supabase functions deploy openrouter --no-verify-jwt

--- a/supabase/functions/openrouter/index.ts
+++ b/supabase/functions/openrouter/index.ts
@@ -26,7 +26,8 @@ const ALLOWED_ORIGINS = Deno.env.get('ALLOWED_ORIGINS') ?? '*';
 const corsHeaders = {
   'Access-Control-Allow-Origin': ALLOWED_ORIGINS,
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  // Supabase JS client sends x-client-info and may send apikey from browser
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
 const DEFAULT_FALLBACK_MODELS = [


### PR DESCRIPTION
### Motivation
- Ensure the OpenRouter edge function accepts headers sent by browser clients (Supabase JS sends `x-client-info` and may include `apikey`) so requests aren't blocked by CORS. 
- Advise production deployments to restrict `ALLOWED_ORIGINS` instead of using `*` to improve security.

### Description
- Update `supabase/functions/openrouter/index.ts` to include `authorization`, `x-client-info`, `apikey`, and `content-type` in `Access-Control-Allow-Headers` so the function accepts those client headers. 
- Keep `ALLOWED_ORIGINS` env var usage and default to `*`, and add guidance in `SETUP.md` to set `ALLOWED_ORIGINS` to the frontend domain in production. 
- Add a `supabase secrets set ALLOWED_ORIGINS=...` example to `SETUP.md` and clarify not to use `*` for production.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13cbbee1cc832b960a06c69b84f800)