### PR TITLE
Allow configurable default models and CORS headers for OpenRouter edge function; update client model list and setup docs

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -48,6 +48,10 @@ supabase link --project-ref YOUR_PROJECT_REF
 # Set secret (lấy từ GitHub Secret hoặc trực tiếp)
 supabase secrets set OPENROUTER_API_KEY=sk-or-...
 supabase secrets set SITE_URL=https://tuongna.github.io
+# Production: không dùng '*', chỉ cho phép đúng domain frontend
+supabase secrets set ALLOWED_ORIGINS=https://tuongna.github.io
+# Optional: override fallback models (comma-separated)
+supabase secrets set OPENROUTER_DEFAULT_MODELS=openai/gpt-4o-mini,anthropic/claude-3.5-haiku
 
 # Deploy function
 supabase functions deploy openrouter --no-verify-jwt

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -10,12 +10,12 @@ const SYSTEM_PROMPT = `You are a Vietnamese-English expert specializing in Scrum
 Given a word or phrase (typically from a Scrum context), respond with JSON only — no markdown fences:
 {"en": "<concise English definition, 1-2 sentences>", "vi": "<Vietnamese translation/explanation, 1-2 sentences>", "note": "<optional usage tip in Vietnamese, or empty string>"}`;
 
-// Tried in order server-side. Free models first, paid 8b as last resort.
+// Tried in order by the edge function. Keep this list current to avoid dead endpoints.
+// gpt-oss-20b:free is capable enough for glossary-style EN↔VI translation.
 const MODELS = [
-  'google/gemini-2.0-flash-exp:free',
-  'meta-llama/llama-3.3-70b-instruct:free',
-  'google/gemma-2-9b-it:free',
-  'google/gemini-flash-1.5-8b',
+  'openai/gpt-oss-20b:free',
+  'meta-llama/llama-3.1-8b-instruct:free',
+  'qwen/qwen-2.5-7b-instruct:free',
 ];
 
 interface OpenRouterChoice {

--- a/supabase/functions/openrouter/index.ts
+++ b/supabase/functions/openrouter/index.ts
@@ -26,14 +26,28 @@ const ALLOWED_ORIGINS = Deno.env.get('ALLOWED_ORIGINS') ?? '*';
 const corsHeaders = {
   'Access-Control-Allow-Origin': ALLOWED_ORIGINS,
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  // Supabase JS client sends x-client-info and may send apikey from browser
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
 const DEFAULT_FALLBACK_MODELS = [
-  'google/gemini-2.0-flash-exp:free',
-  'meta-llama/llama-3.3-70b-instruct:free',
-  'google/gemma-2-9b-it:free',
+  // Prefer broadly available models; project can override with OPENROUTER_DEFAULT_MODELS
+  'openai/gpt-4o-mini',
+  'anthropic/claude-3.5-haiku',
+  'meta-llama/llama-3.1-8b-instruct',
 ];
+
+function parseDefaultModelsFromEnv(): string[] {
+  const raw = Deno.env.get('OPENROUTER_DEFAULT_MODELS')?.trim();
+  if (!raw) return DEFAULT_FALLBACK_MODELS;
+
+  const parsed = raw
+    .split(',')
+    .map((m) => m.trim())
+    .filter(Boolean);
+
+  return parsed.length ? parsed : DEFAULT_FALLBACK_MODELS;
+}
 
 serve(async (req: Request) => {
   if (req.method === 'OPTIONS') {
@@ -62,9 +76,12 @@ serve(async (req: Request) => {
     return json({ errors: ['Invalid JSON body'] }, 200);
   }
 
-  const candidates =
+  const requested =
     (Array.isArray(body.models) && body.models.length ? body.models : null) ??
-    (body.model ? [body.model] : DEFAULT_FALLBACK_MODELS);
+    (body.model ? [body.model] : []);
+
+  // Always append service defaults so one bad client model does not hard-fail translation.
+  const candidates = [...new Set([...requested, ...parseDefaultModelsFromEnv()])];
 
   const errors: string[] = [];
 


### PR DESCRIPTION
### Motivation
- Make the OpenRouter edge proxy more robust by allowing projects to override fallback models and preventing client-side CORS rejections from additional headers.  
- Keep the client-side model list aligned with available/cheap models and document required secrets including allowed origins.  

### Description
- Update `SETUP.md` to instruct setting `ALLOWED_ORIGINS` and `OPENROUTER_DEFAULT_MODELS` and show example `supabase secrets set` commands.  
- Change `src/lib/ai.ts` to use an updated `MODELS` list and adjust the comment to reflect that ordering is handled by the edge function.  
- Modify `supabase/functions/openrouter/index.ts` to include extra CORS allowed headers (`authorization`, `x-client-info`, `apikey`, `content-type`) and to read `OPENROUTER_DEFAULT_MODELS` via a new `parseDefaultModelsFromEnv()` function.  
- Build the set of candidate models by combining client-requested models with service defaults (deduplicated) so a bad client model does not hard-fail requests, and keep returning the unified envelope `{ data?, model?, errors? }`.  

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13cbbee1cc832b960a06c69b84f800)