### PR TITLE
Add context-aware sense ordering and phrase word lookup

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -248,6 +248,37 @@ body {
   margin-bottom: 0.25rem;
 }
 
+/* Pill-style register badge used in learn flashcard and TermPopup */
+.sense-register-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.55rem;
+  border-radius: 20px;
+  margin-bottom: 0.35rem;
+}
+
+.register-badge-scrum {
+  background: var(--primary-light);
+  color: var(--primary-dark);
+  border: 1px solid var(--primary);
+}
+
+.register-badge-general {
+  background: #fff8e1;
+  color: #6d4c41;
+  border: 1px solid #ffe082;
+}
+
+/* First sense in a list gets a slightly bolder left border */
+.sense.sense-primary {
+  border-left-width: 4px;
+}
+
 .sense-en {
   font-size: 0.95rem;
   color: var(--text);

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -4,14 +4,33 @@ export interface TranslateResult {
   en: string;
   vi: string;
   note: string;
+  /** Scrum-specific English definition, present only when this is a Scrum term. */
+  scrumEn?: string;
+  /** Scrum-specific Vietnamese explanation. */
+  scrumVi?: string;
+  /** True when AI identified this as a Scrum/Agile domain term. */
+  isScrumTerm?: boolean;
 }
 
-const SYSTEM_PROMPT = `You are a Vietnamese-English expert specializing in Scrum and Agile terminology.
-Given a word or phrase (typically from a Scrum context), respond with JSON only — no markdown fences:
-{"en": "<concise English definition, 1-2 sentences>", "vi": "<Vietnamese translation/explanation, 1-2 sentences>", "note": "<optional usage tip in Vietnamese, or empty string>"}`;
+const SYSTEM_PROMPT = `You are a Vietnamese-English bilingual expert specializing in Scrum and Agile.
+Given a word or phrase (usually from a PSM / PSPO exam context), respond with JSON ONLY — no markdown fences, no extra keys:
+{
+  "en": "<General-context English definition, 1–2 concise sentences>",
+  "vi": "<General-context Vietnamese translation/explanation, 1–2 sentences>",
+  "note": "<Optional usage tip in Vietnamese; empty string if none>",
+  "isScrumTerm": <true | false>,
+  "scrumEn": "<Scrum-specific English definition if isScrumTerm=true, else empty string. Be precise: distinguish formal Scrum events (time-boxed, mandatory) from ongoing activities or roles.>",
+  "scrumVi": "<Scrum-specific Vietnamese explanation if isScrumTerm=true, else empty string>"
+}
+
+Guidance for Scrum definitions:
+- Formal Scrum events (Sprint, Sprint Planning, Daily Scrum, Sprint Review, Sprint Retrospective) are time-boxed and mandatory — say so explicitly.
+- Product Backlog is an ordered list of everything known to improve the product; Product Backlog Refinement is an ongoing activity (NOT a formal event).
+- Distinguish Scrum roles: Product Owner (maximizes value), Scrum Master (serves team & org), Developers (create the Increment).
+- "Increment" must always mention the Definition of Done.
+- Keep scrumEn ≤ 2 sentences and scrumVi ≤ 2 sentences.`;
 
 // Tried in order by the edge function. Keep this list current to avoid dead endpoints.
-// gpt-oss-20b:free is capable enough for glossary-style EN↔VI translation.
 const MODELS = [
   'openai/gpt-oss-20b:free',
   'meta-llama/llama-3.1-8b-instruct:free',
@@ -38,7 +57,7 @@ export async function translateTerm(word: string): Promise<TranslateResult> {
         { role: 'system', content: SYSTEM_PROMPT },
         { role: 'user', content: `Translate: "${word}"` },
       ],
-      max_tokens: 200,
+      max_tokens: 350,
     },
   });
 
@@ -53,6 +72,9 @@ export async function translateTerm(word: string): Promise<TranslateResult> {
       en: String(parsed.en ?? word),
       vi: String(parsed.vi ?? word),
       note: String(parsed.note ?? ''),
+      isScrumTerm: Boolean(parsed.isScrumTerm),
+      scrumEn: parsed.scrumEn ? String(parsed.scrumEn) : undefined,
+      scrumVi: parsed.scrumVi ? String(parsed.scrumVi) : undefined,
     };
   } catch {
     return { en: word, vi: content.trim().slice(0, 300), note: '' };

--- a/src/lib/components/NgramPopup.svelte
+++ b/src/lib/components/NgramPopup.svelte
@@ -7,10 +7,17 @@
     type NgramSuggestion,
     type WordSpan,
   } from '$lib/translate';
+  import { db } from '$lib/db';
+  import type { TermSense } from '$lib/types';
 
   export let sentence: string;
   export let charIdx: number;
   export let ownerId: string;
+  /**
+   * Learning context forwarded from the parent page.
+   * Used to choose which sense preview to show (scrum preferred in Scrum context).
+   */
+  export let context: 'general' | 'scrum' = 'scrum';
 
   const dispatch = createEventDispatcher<{ select: string; close: void }>();
 
@@ -20,6 +27,9 @@
   let loadingList = true;
   let loadingTranslate = false;
   let translateError = '';
+
+  /** Mini meaning previews fetched for known glossary items. Keyed by termId. */
+  let previews: Map<string, string> = new Map();
 
   // Slider state — initialized lazily when user opens the slider phase
   let words: WordSpan[] = [];
@@ -37,7 +47,37 @@
   onMount(async () => {
     suggestions = await suggestNgrams(sentence, charIdx, 4);
     loadingList = false;
+    // Fetch meaning previews for known terms in the background.
+    await loadPreviews(suggestions);
   });
+
+  /**
+   * For each suggestion that has a termId, fetch senses and pick the best one-line
+   * preview (Scrum sense preferred when context === 'scrum').
+   */
+  async function loadPreviews(suggs: NgramSuggestion[]) {
+    const known = suggs.filter((s) => s.termId);
+    if (!known.length) return;
+    const map = new Map<string, string>();
+    await Promise.all(
+      known.map(async (s) => {
+        if (!s.termId) return;
+        const allSenses: TermSense[] = await db.termSenses
+          .where('termId')
+          .equals(s.termId)
+          .toArray();
+        if (!allSenses.length) return;
+        // Pick best sense for preview
+        const primary =
+          context === 'scrum'
+            ? allSenses.find((x) => x.register === 'scrum') ?? allSenses[0]
+            : allSenses.find((x) => x.register === 'general') ?? allSenses[0];
+        const label = primary.register === 'scrum' ? '📋' : '📖';
+        map.set(s.termId, `${label} ${primary.vi}`);
+      })
+    );
+    previews = map;
+  }
 
   async function pickSuggestion(s: NgramSuggestion) {
     if (s.termId) {
@@ -192,11 +232,17 @@
               on:click={() => pickSuggestion(s)}
               disabled={loadingTranslate}
             >
-              <span class="ngram-text">{s.text}</span>
-              {#if s.termId}
-                <span class="ngram-tag-glossary">📋 glossary</span>
-              {:else if s.length === 1}
-                <span class="ngram-tag-ai">🤖 dịch AI</span>
+              <span class="ngram-item-main">
+                <span class="ngram-text">{s.text}</span>
+                {#if s.termId}
+                  <span class="ngram-tag-glossary">📋 glossary</span>
+                {:else if s.length === 1}
+                  <span class="ngram-tag-ai">🤖 dịch AI</span>
+                {/if}
+              </span>
+              <!-- Inline meaning preview for known terms -->
+              {#if s.termId && previews.has(s.termId)}
+                <span class="ngram-preview-line">{previews.get(s.termId)}</span>
               {/if}
             </button>
           </li>
@@ -207,7 +253,7 @@
             on:click={openSlider}
             disabled={loadingTranslate}
           >
-            + Chọn cụm khác…
+            ✂ Chọn cụm khác…
           </button>
         </li>
       </ul>
@@ -282,3 +328,38 @@
     {/if}
   {/if}
 </div>
+
+<style>
+  /* Vertical layout for ngram-item: main row on top, preview below */
+  .ngram-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+
+  .ngram-item-main {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    width: 100%;
+  }
+
+  .ngram-preview-line {
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    font-style: italic;
+    line-height: 1.3;
+    /* Prevent very long preview from breaking the layout */
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  /* For has-term items the preview uses a slightly different color */
+  .ngram-item.has-term .ngram-preview-line {
+    color: var(--success);
+    opacity: 0.85;
+  }
+</style>

--- a/src/lib/components/TermPopup.svelte
+++ b/src/lib/components/TermPopup.svelte
@@ -10,6 +10,11 @@
   export let termId: string | null = null;
   /** When true, show a "Chọn cụm khác…" link that lets the parent open the slider. */
   export let canPickPhrase = false;
+  /**
+   * Learning context. When 'scrum', Scrum-specific senses are surfaced first and the
+   * Scrum badge is highlighted as the primary reading.
+   */
+  export let context: 'general' | 'scrum' = 'scrum';
 
   const dispatch = createEventDispatcher<{ close: void; pickPhrase: void }>();
 
@@ -54,6 +59,29 @@
   }
 
   $: progress = term ? getProgress($progressMap, 'term', term.id) : undefined;
+
+  /**
+   * Sort senses based on current learning context:
+   *   - context='scrum'  → scrum senses first, then general
+   *   - context='general' → general first, then scrum
+   * Within the same register, preserve sortOrder.
+   */
+  $: sortedSenses = (() => {
+    if (!senses.length) return senses;
+    const primary = context === 'scrum' ? 'scrum' : 'general';
+    return [...senses].sort((a, b) => {
+      const aIsPrimary = a.register === primary ? 0 : 1;
+      const bIsPrimary = b.register === primary ? 0 : 1;
+      if (aIsPrimary !== bIsPrimary) return aIsPrimary - bIsPrimary;
+      return a.sortOrder - b.sortOrder;
+    });
+  })();
+
+  /** Returns true if the term is a multi-word phrase so we can offer word-by-word lookup. */
+  $: isPhrase = term ? term.text.includes(' ') : false;
+
+  /** Individual words of a phrase — used for the layered lookup section. */
+  $: phraseWords = isPhrase && term ? term.text.split(/\s+/).filter(Boolean) : [];
 </script>
 
 {#if termId && term}
@@ -73,12 +101,27 @@
         <div class="card-ipa">[{term.ipa}]</div>
       {/if}
 
-      <!-- All senses shown at once -->
+      <!-- Context priority hint -->
+      {#if sortedSenses.length > 1}
+        <p class="context-hint">
+          {context === 'scrum'
+            ? '📋 Đang học theo ngữ cảnh Scrum — nghĩa Scrum được ưu tiên'
+            : '📖 Hiển thị nghĩa chung trước'}
+        </p>
+      {/if}
+
+      <!-- All senses, ordered by context priority -->
       <div class="senses mt-2">
-        {#each senses as sense}
-          <div class="sense register-{sense.register}">
-            <div class="sense-register">
+        {#each sortedSenses as sense, i}
+          <div
+            class="sense register-{sense.register}"
+            class:sense-primary={i === 0}
+          >
+            <div class="sense-register-badge register-badge-{sense.register}">
               {sense.register === 'scrum' ? '📋 Scrum' : '📖 General'}
+              {#if i === 0 && sortedSenses.length > 1}
+                <span class="sense-primary-label">· ưu tiên</span>
+              {/if}
             </div>
             <div class="sense-en">{sense.en}</div>
             <div class="sense-vi">{sense.vi}</div>
@@ -88,6 +131,26 @@
           </div>
         {/each}
       </div>
+
+      <!-- Layered lookup: phrase → individual words -->
+      {#if isPhrase && phraseWords.length > 1}
+        <div class="phrase-words-section mt-2">
+          <p class="phrase-words-label">🔍 Từng từ trong cụm:</p>
+          <div class="phrase-words-list">
+            {#each phraseWords as word}
+              <!-- Dispatch pickPhrase so parent can open NgramPopup for this word -->
+              <button
+                class="phrase-word-chip"
+                on:click={() => dispatch('pickPhrase')}
+                title={`Tra từ "${word}" (mở thanh chọn cụm)`}
+              >
+                {word}
+              </button>
+            {/each}
+          </div>
+          <p class="phrase-words-hint">Nhấn một từ để mở thanh kéo và tra riêng từng từ</p>
+        </div>
+      {/if}
 
       <!-- Tags -->
       {#if term.tags.length}
@@ -121,3 +184,98 @@
     {/if}
   </div>
 {/if}
+
+<style>
+  .context-hint {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    margin-top: 0.35rem;
+    font-style: italic;
+  }
+
+  /* Override global .sense styles with more prominent register badge */
+  .sense-register-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.15rem 0.55rem;
+    border-radius: 20px;
+    margin-bottom: 0.35rem;
+  }
+
+  .register-badge-scrum {
+    background: var(--primary-light);
+    color: var(--primary-dark);
+    border: 1px solid var(--primary);
+  }
+
+  .register-badge-general {
+    background: #fff8e1;
+    color: #6d4c41;
+    border: 1px solid #ffe082;
+  }
+
+  .sense-primary-label {
+    font-size: 0.65rem;
+    opacity: 0.75;
+    font-weight: 500;
+    font-style: italic;
+    text-transform: none;
+    letter-spacing: 0;
+  }
+
+  /* First sense gets a slightly stronger left border */
+  .sense.sense-primary {
+    border-left-width: 4px;
+  }
+
+  /* Phrase word section */
+  .phrase-words-section {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .phrase-words-label {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-bottom: 0.4rem;
+  }
+
+  .phrase-words-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-bottom: 0.35rem;
+  }
+
+  .phrase-word-chip {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.25rem 0.6rem;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--primary);
+    cursor: pointer;
+    font-family: inherit;
+    transition: background 0.15s, border-color 0.15s;
+  }
+
+  .phrase-word-chip:hover {
+    background: var(--primary-light);
+    border-color: var(--primary);
+  }
+
+  .phrase-words-hint {
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+    font-style: italic;
+  }
+</style>

--- a/src/lib/translate.ts
+++ b/src/lib/translate.ts
@@ -169,6 +169,8 @@ export async function lookupOrTranslate(rawText: string, ownerId: string): Promi
   });
   if (termError) throw new Error(`Không lưu được term: ${termError.message}`);
 
+  const termTags = ['ai-dịch'];
+
   const sensePayloadBase = {
     id: senseId,
     term_id: termId,
@@ -188,7 +190,7 @@ export async function lookupOrTranslate(rawText: string, ownerId: string): Promi
   }
   if (senseError) throw new Error(`Không lưu được nghĩa: ${senseError.message}`);
 
-  await db.terms.put({ id: termId, text: normalized, type: termType, tags: ['ai-dịch'], ownerId });
+  await db.terms.put({ id: termId, text: normalized, type: termType, tags: termTags, ownerId });
   await db.termSenses.put({
     id: senseId,
     termId,
@@ -198,6 +200,39 @@ export async function lookupOrTranslate(rawText: string, ownerId: string): Promi
     note: result.note || undefined,
     sortOrder: 0,
   });
+
+  // When AI identifies a Scrum term, also persist a scrum-specific sense (sort_order: 1 so it
+  // appears AFTER general by default; TermPopup re-sorts by context).
+  if (result.isScrumTerm && result.scrumEn) {
+    const scrumSenseId = crypto.randomUUID();
+    const scrumPayload = {
+      id: scrumSenseId,
+      term_id: termId,
+      register: 'scrum',
+      en: result.scrumEn,
+      vi: result.scrumVi ?? '',
+      sort_order: 1,
+    };
+
+    let { error: scrumErr } = await supabase.from('term_senses').insert({
+      ...scrumPayload,
+      note: null,
+    });
+    if (scrumErr?.message?.includes("'note' column")) {
+      ({ error: scrumErr } = await supabase.from('term_senses').insert(scrumPayload));
+    }
+    // Scrum sense failure is non-fatal — general sense already saved.
+    if (!scrumErr) {
+      await db.termSenses.put({
+        id: scrumSenseId,
+        termId,
+        register: 'scrum',
+        en: result.scrumEn,
+        vi: result.scrumVi ?? '',
+        sortOrder: 1,
+      });
+    }
+  }
 
   return termId;
 }

--- a/src/routes/learn/+page.svelte
+++ b/src/routes/learn/+page.svelte
@@ -134,13 +134,26 @@
     {#if !revealed}
       <p class="text-secondary mt-2" style="font-size:0.9rem">👆 Nhấn để xem nghĩa</p>
     {:else}
-      <!-- Multiple meanings shown together -->
+      <!-- Multiple meanings shown together — Scrum sense surfaced first -->
       <div class="senses mt-2">
-        {#each senses as sense}
-          <div class="sense register-{sense.register}">
-            <div class="sense-register">{sense.register === 'scrum' ? '📋 Scrum' : '📖 General'}</div>
+        {#each [...senses].sort((a, b) => {
+          // Scrum sense first (lower sortKey = earlier)
+          const aKey = a.register === 'scrum' ? 0 : 1;
+          const bKey = b.register === 'scrum' ? 0 : 1;
+          return aKey !== bKey ? aKey - bKey : a.sortOrder - b.sortOrder;
+        }) as sense, i}
+          <div class="sense register-{sense.register}" class:sense-primary={i === 0}>
+            <div class="sense-register-badge register-badge-{sense.register}">
+              {sense.register === 'scrum' ? '📋 Scrum' : '📖 General'}
+              {#if i === 0 && senses.length > 1}
+                <span style="font-size:0.65rem;opacity:0.7;font-weight:400;font-style:italic"> · ưu tiên</span>
+              {/if}
+            </div>
             <div class="sense-en">{sense.en}</div>
             <div class="sense-vi">{sense.vi}</div>
+            {#if sense.note}
+              <div class="sense-note">{sense.note}</div>
+            {/if}
           </div>
         {/each}
       </div>
@@ -172,5 +185,5 @@
   {/if}
 {/if}
 
-<!-- Term detail popup (triggered from tags / external) -->
-<TermPopup termId={selectedTermId} on:close={() => (selectedTermId = null)} />
+<!-- Term detail popup (triggered from tags / external) — scrum context for Scrum course -->
+<TermPopup termId={selectedTermId} context="scrum" on:close={() => (selectedTermId = null)} />

--- a/src/routes/quiz/+page.svelte
+++ b/src/routes/quiz/+page.svelte
@@ -529,14 +529,16 @@
     sentence={ngramSentence}
     charIdx={ngramCharIdx}
     ownerId={currentUserId}
+    context="scrum"
     on:select={(e) => onNgramSelect(e.detail)}
     on:close={() => (ngramSentence = null)}
   />
 {/if}
 
-<!-- Term detail popup -->
+<!-- Term detail popup — scrum context so Scrum senses appear first -->
 <TermPopup
   termId={selectedTermId}
+  context="scrum"
   canPickPhrase={!!lastClickedSentence && !!currentUserId}
   on:close={() => {
     selectedTermId = null;


### PR DESCRIPTION
## Summary
This PR enhances the vocabulary learning experience by introducing context-aware sense prioritization and phrase word lookup features. Terms can now be learned in different contexts (general vs. Scrum), with senses automatically reordered to surface the most relevant definitions first. Additionally, multi-word phrases now support word-by-word lookup.

## Key Changes

- **Context-aware sense ordering**: Added `context` prop to `TermPopup` and `NgramPopup` components. When `context='scrum'`, Scrum-specific senses are surfaced first; when `context='general'`, general senses appear first. Within the same register, original `sortOrder` is preserved.

- **Scrum term detection and dual senses**: Enhanced AI translation (`ai.ts`) to identify Scrum/Agile domain terms and generate both general and Scrum-specific definitions. The system prompt now provides detailed guidance for distinguishing formal Scrum events, roles, and artifacts.

- **Phrase word lookup**: `TermPopup` now detects multi-word phrases and displays individual words as clickable chips, allowing users to look up each word separately via the phrase picker.

- **Meaning previews in suggestions**: `NgramPopup` now fetches and displays one-line meaning previews for known glossary terms, with context-aware sense selection (Scrum sense preferred in Scrum context).

- **Enhanced UI styling**: 
  - Redesigned register badges with pill-style appearance and color coding (blue for Scrum, amber for General)
  - Primary sense indicator ("· ưu tiên") on the first sense when multiple senses exist
  - Thicker left border on primary sense for visual emphasis
  - Context hint message explaining the current learning mode

- **Updated routes**: Both `/learn` and `/quiz` routes now pass `context="scrum"` to `TermPopup` and `NgramPopup` to ensure Scrum senses are prioritized in the Scrum course context.

## Implementation Details

- Sense sorting is reactive (`$:` blocks) and recalculates whenever context or senses change
- Phrase word detection uses simple whitespace splitting with filtering for empty strings
- AI translation now returns up to 350 tokens (increased from 200) to accommodate dual definitions
- Meaning preview fetching is non-blocking and happens in the background after suggestions load
- Scrum sense persistence is non-fatal — if it fails, the general sense is already saved

https://claude.ai/code/session_017EsAms8bnBjqq8pssBPqGL