### PR TITLE
feat: Scrum-context re-translation for cached terms missing Scrum sense

### DIFF
--- a/src/lib/components/NgramPopup.svelte
+++ b/src/lib/components/NgramPopup.svelte
@@ -41,6 +41,13 @@
   let finalElapsed = 0;
   let elapsedInterval: ReturnType<typeof setInterval> | null = null;
 
+  /**
+   * True while translateAndSelect is running for a term that already existed in
+   * the glossary (Scrum-sense enrichment path), as opposed to a brand-new translation.
+   * Used to show "Bổ sung nghĩa Scrum…" instead of "Đang dịch AI…".
+   */
+  let enrichingScrum = false;
+
   /** Next model in MODELS that will be tried if the current one fails. */
   $: nextModelToTry = (() => {
     if (!loadingTranslate) return null;
@@ -128,6 +135,25 @@
 
   async function pickSuggestion(s: NgramSuggestion) {
     if (s.termId) {
+      // In Scrum context: only dispatch immediately if a Scrum sense is already cached.
+      // Otherwise, route through translateAndSelect so the AI can enrich it.
+      if (context === 'scrum') {
+        const scrumCount = await db.termSenses
+          .where('termId')
+          .equals(s.termId)
+          .filter((sense) => sense.register === 'scrum')
+          .count();
+        if (scrumCount === 0) {
+          // Term exists but has no Scrum sense — re-translate to enrich, then open.
+          enrichingScrum = true;
+          try {
+            await translateAndSelect(s.text);
+          } finally {
+            enrichingScrum = false;
+          }
+          return;
+        }
+      }
       dispatch('select', s.termId);
       return;
     }
@@ -141,15 +167,20 @@
     attempts = [];
     startElapsedTimer();
     try {
-      const termId = await lookupOrTranslate(text, ownerId, (a) => {
-        // Merge updates: when a model transitions trying → failed/succeeded, replace its row.
-        const last = attempts[attempts.length - 1];
-        if (last && last.model === a.model && last.status === 'trying') {
-          attempts = [...attempts.slice(0, -1), a];
-        } else {
-          attempts = [...attempts, a];
-        }
-      });
+      const termId = await lookupOrTranslate(
+        text,
+        ownerId,
+        (a) => {
+          // Merge updates: when a model transitions trying → failed/succeeded, replace its row.
+          const last = attempts[attempts.length - 1];
+          if (last && last.model === a.model && last.status === 'trying') {
+            attempts = [...attempts.slice(0, -1), a];
+          } else {
+            attempts = [...attempts, a];
+          }
+        },
+        context,
+      );
       dispatch('select', termId);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -325,10 +356,10 @@
             <span class="tp-status">
               {#if loadingTranslate}
                 <span class="tp-spinner" aria-hidden="true"></span>
-                Đang dịch AI…
+                {enrichingScrum ? '📋 Bổ sung nghĩa Scrum…' : 'Đang dịch AI…'}
               {:else}
                 <span class="tp-ok-icon" aria-hidden="true">✓</span>
-                Đã dịch xong
+                {enrichingScrum ? '📋 Đã bổ sung Scrum' : 'Đã dịch xong'}
               {/if}
             </span>
             {#if loadingTranslate && elapsedSeconds >= 1}

--- a/src/lib/translate.ts
+++ b/src/lib/translate.ts
@@ -145,18 +145,40 @@ export async function suggestNgrams(
 /**
  * Returns the term ID for rawText, creating it via AI translation if not cached.
  * Writes new translations to both Supabase (persistent) and Dexie (local cache).
+ *
+ * When `context` is `'scrum'` and the term already exists in cache but has no
+ * Scrum-specific sense, re-translates to try to enrich it (non-fatal: if the AI
+ * doesn't identify it as a Scrum term, the existing general sense is kept as-is).
  */
 export async function lookupOrTranslate(
   rawText: string,
   ownerId: string,
   onAttempt?: OnAttempt,
+  context: 'general' | 'scrum' = 'general',
 ): Promise<string> {
   const normalized = rawText.trim();
 
   const existing = await db.terms
     .filter((t) => t.text.toLowerCase() === normalized.toLowerCase())
     .first();
-  if (existing) return existing.id;
+
+  if (existing) {
+    // In Scrum context, check whether a Scrum-specific sense already exists.
+    // If not, re-translate to attempt enrichment (only the scrum sense is added;
+    // the existing general sense is never replaced).
+    if (context === 'scrum') {
+      const scrumSenseCount = await db.termSenses
+        .where('termId')
+        .equals(existing.id)
+        .filter((s) => s.register === 'scrum')
+        .count();
+
+      if (scrumSenseCount === 0) {
+        await enrichScrumSense(existing.id, normalized, ownerId, onAttempt);
+      }
+    }
+    return existing.id;
+  }
 
   const { result, model } = await translateTerm(normalized, onAttempt);
 
@@ -241,6 +263,58 @@ export async function lookupOrTranslate(
   }
 
   return termId;
+}
+
+/**
+ * Re-translates `text` and, if the AI identifies it as a Scrum term, inserts the
+ * Scrum sense into Supabase and Dexie for `termId`. The existing general sense is
+ * never modified. Errors are swallowed so the caller always gets a termId back.
+ */
+async function enrichScrumSense(
+  termId: string,
+  text: string,
+  ownerId: string,
+  onAttempt?: OnAttempt,
+): Promise<void> {
+  let result: import('./ai').TranslateResult;
+  try {
+    ({ result } = await translateTerm(text, onAttempt));
+  } catch {
+    // All models failed — keep existing general sense, no Scrum enrichment.
+    return;
+  }
+
+  if (!result.isScrumTerm || !result.scrumEn) return;
+
+  const scrumSenseId = crypto.randomUUID();
+  const scrumPayload = {
+    id: scrumSenseId,
+    term_id: termId,
+    register: 'scrum',
+    en: result.scrumEn,
+    vi: result.scrumVi ?? '',
+    sort_order: 1,
+  };
+
+  let { error: scrumErr } = await supabase.from('term_senses').insert({
+    ...scrumPayload,
+    note: null,
+  });
+  if (scrumErr?.message?.includes("'note' column")) {
+    ({ error: scrumErr } = await supabase.from('term_senses').insert(scrumPayload));
+  }
+
+  if (!scrumErr) {
+    await db.termSenses.put({
+      id: scrumSenseId,
+      termId,
+      register: 'scrum',
+      en: result.scrumEn,
+      vi: result.scrumVi ?? '',
+      sortOrder: 1,
+    });
+  }
+  // Ignore scrumErr — non-fatal; the term still opens with its general sense.
 }
 
 function isLetter(ch: string): boolean {


### PR DESCRIPTION
Problem: lookupOrTranslate returned cached termId immediately even when the existing translation had no Scrum-specific sense (isScrumTerm=false at the time of first translation, or translated before Scrum enrichment existed).

Changes:

translate.ts
- lookupOrTranslate(... context: 'general'|'scrum' = 'general'): when context='scrum' and existing term has no scrum sense in Dexie, calls new enrichScrumSense() before returning the cached termId
- enrichScrumSense(): re-translates via the full MODELS fallback chain, saves only the scrum sense (term_senses register='scrum') to Supabase
  + Dexie without touching the existing general sense; swallows errors so a failed enrichment never blocks the user from opening the term

NgramPopup.svelte
- pickSuggestion() for existing glossary items (s.termId set): in scrum context, checks db.termSenses for a scrum sense first; if missing, routes through translateAndSelect (shows progress UI) instead of dispatching 'select' immediately
- translateAndSelect() passes context to lookupOrTranslate
- enrichingScrum flag: progress header shows '📋 Bổ sung nghĩa Scrum…' instead of generic 'Đang dịch AI…' during enrichment flow; flag reset in try/finally so it never sticks on error

https://claude.ai/code/session_01NpNErvJHsW4MSeEdQBJBNs