### PR TITLE
fix: dedupe Scrum Open pools, add idempotency + UNIQUE(stem)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -34,6 +34,10 @@
    ở mức DB (nếu crawl thêm bộ mới, INSERT sẽ fail nếu stem trùng — bạn biết được
    ngay câu nào trùng để xử lý).
 
+   **Thêm pool mới từ markdown crawl:** xem `docs/quiz-import-prompt.md` — chứa
+   prompt sẵn để paste vào AI bất kỳ (Claude/GPT/Gemini) để convert raw markdown
+   sang file `seed_scrum_open_vN.sql`.
+
 ### 3. Cài GitHub Secrets
 
 Vào repository → Settings → Secrets and variables → Actions → New repository secret:

--- a/SETUP.md
+++ b/SETUP.md
@@ -9,7 +9,7 @@
 3. Chạy migrations trong Supabase SQL Editor (theo thứ tự):
    - `supabase/migrations/001_schema.sql` → `002_rls.sql` → `003_ai_terms.sql`
    - `supabase/migrations/004_public_questions.sql` → `005_question_source.sql`
-   - `supabase/migrations/006_unique_question_stem.sql` (ngăn câu hỏi trùng stem)
+   - `supabase/migrations/006_normalize_scrum_open.sql` (tag pool-1 legacy + UNIQUE stem)
 4. Bật Auth → Providers → **Google** (cần Google Cloud OAuth credentials).
 5. Trong Authentication → URL Configuration:
    - Site URL: `https://tuongna.github.io` (hoặc URL app của bạn)
@@ -30,7 +30,7 @@
 
    **Chống trùng:** mỗi seed có `DELETE ... WHERE 'scrum-open-pool-N' = ANY(tags)` ở
    đầu file → chạy lại file nào chỉ xóa data của pool đó, không động đến pool còn
-   lại. Migration `006_unique_question_stem.sql` cũng ngăn 2 câu hỏi có cùng stem
+   lại. Migration `006_normalize_scrum_open.sql` cũng ngăn 2 câu hỏi có cùng stem
    ở mức DB (nếu crawl thêm bộ mới, INSERT sẽ fail nếu stem trùng — bạn biết được
    ngay câu nào trùng để xử lý).
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -34,6 +34,11 @@
    ở mức DB (nếu crawl thêm bộ mới, INSERT sẽ fail nếu stem trùng — bạn biết được
    ngay câu nào trùng để xử lý).
 
+   **UUID tĩnh:** cả hai file seed dùng UUID cứng (hardcoded) thay vì `gen_random_uuid()`
+   → chạy lại seed sẽ xóa và tái tạo câu hỏi với **cùng UUID**, bảo tồn bản ghi
+   `public.progress` của người dùng. File seed mới cũng cần làm tương tự — xem
+   hướng dẫn sinh UUID trong `docs/quiz-import-prompt.md`.
+
    **Thêm pool mới từ markdown crawl:** xem `docs/quiz-import-prompt.md` — chứa
    prompt sẵn để paste vào AI bất kỳ (Claude/GPT/Gemini) để convert raw markdown
    sang file `seed_scrum_open_vN.sql`.

--- a/SETUP.md
+++ b/SETUP.md
@@ -7,8 +7,9 @@
 1. Vào [supabase.com](https://supabase.com) → New project → đặt tên `kfr`.
 2. Ghi lại **Project URL** và **anon public key** (Settings → API).
 3. Chạy migrations trong Supabase SQL Editor (theo thứ tự):
-   - `supabase/migrations/001_schema.sql`
-   - `supabase/migrations/002_rls.sql`
+   - `supabase/migrations/001_schema.sql` → `002_rls.sql` → `003_ai_terms.sql`
+   - `supabase/migrations/004_public_questions.sql` → `005_question_source.sql`
+   - `supabase/migrations/006_unique_question_stem.sql` (ngăn câu hỏi trùng stem)
 4. Bật Auth → Providers → **Google** (cần Google Cloud OAuth credentials).
 5. Trong Authentication → URL Configuration:
    - Site URL: `https://tuongna.github.io` (hoặc URL app của bạn)
@@ -24,8 +25,14 @@
 3. Sửa `supabase/seed.sql`: thay `YOUR_USER_ID` bằng ID thực.
 4. Chạy seed trong SQL Editor.
 5. (Tùy chọn) Seed thêm bộ câu hỏi Scrum Open Assessment (PSM-I, public, không cần user ID):
-   - `supabase/seed_scrum_open.sql` — bộ 30 câu hỏi pool 1
-   - `supabase/seed_scrum_open_v2.sql` — bộ 30 câu hỏi pool 2 (mẫu khác từ Scrum Open)
+   - `supabase/seed_scrum_open.sql` — Pool 1: 30 câu (tag `scrum-open-pool-1`)
+   - `supabase/seed_scrum_open_v2.sql` — Pool 2: 30 câu (tag `scrum-open-pool-2`)
+
+   **Chống trùng:** mỗi seed có `DELETE ... WHERE 'scrum-open-pool-N' = ANY(tags)` ở
+   đầu file → chạy lại file nào chỉ xóa data của pool đó, không động đến pool còn
+   lại. Migration `006_unique_question_stem.sql` cũng ngăn 2 câu hỏi có cùng stem
+   ở mức DB (nếu crawl thêm bộ mới, INSERT sẽ fail nếu stem trùng — bạn biết được
+   ngay câu nào trùng để xử lý).
 
 ### 3. Cài GitHub Secrets
 

--- a/docs/quiz-import-prompt.md
+++ b/docs/quiz-import-prompt.md
@@ -12,7 +12,7 @@ seed SQL theo schema của repo này.
 3. AI trả về 1 file SQL. Lưu vào `supabase/seed_scrum_open_vN.sql` (N = pool
    number tiếp theo) → paste vào Supabase SQL Editor.
 
-Nếu DB đã có migration `006_unique_question_stem.sql`, INSERT trùng stem sẽ
+Nếu DB đã có migration `006_normalize_scrum_open.sql`, INSERT trùng stem sẽ
 fail loud → bạn biết câu nào trùng, gỡ khỏi seed mới rồi chạy lại.
 
 ---

--- a/docs/quiz-import-prompt.md
+++ b/docs/quiz-import-prompt.md
@@ -1,0 +1,256 @@
+# Quiz Import Prompt — markdown crawl → seed SQL
+
+Mục đích: cho phép AI bất kỳ (Claude, GPT, Gemini…) convert markdown crawl từ
+[Scrum.org Open Assessment](https://www.scrum.org/open-assessments) sang file
+seed SQL theo schema của repo này.
+
+## Cách dùng (3 bước)
+
+1. Crawl xong → có 1 block markdown chứa ~30 câu hỏi (xem mẫu input bên dưới).
+2. Mở session AI mới → paste **toàn bộ prompt template** ở dưới → paste markdown
+   của bạn sau dòng `<<INPUT_START>>`.
+3. AI trả về 1 file SQL. Lưu vào `supabase/seed_scrum_open_vN.sql` (N = pool
+   number tiếp theo) → paste vào Supabase SQL Editor.
+
+Nếu DB đã có migration `006_unique_question_stem.sql`, INSERT trùng stem sẽ
+fail loud → bạn biết câu nào trùng, gỡ khỏi seed mới rồi chạy lại.
+
+---
+
+## Prompt template (copy toàn bộ vào AI)
+
+```
+You are converting a raw markdown dump from scrum.org Open Assessment into a
+PostgreSQL seed file for the KfR Scrum learning app.
+
+# INPUT FORMAT
+The markdown contains 20-30 numbered questions. Each question looks like:
+
+    Question N of M
+
+    <stem text>
+
+    **(choose the best answer)**          <-- single-correct (4 options A-D/E)
+    **(choose the best two answers)**     <-- multi-select, 2 correct
+    **(choose the best three answers)**   <-- multi-select, 3 correct
+    **True or False:** <stem>             <-- T/F, 2 options
+
+    A. <option text>
+    B. <option text>
+    C. <option text>
+    D. <option text>
+
+    Feedback
+    <explanation paragraph — read this to determine correct answer(s)>
+
+# OUTPUT REQUIREMENTS
+
+Produce a single SQL file. Do NOT include markdown fences in the output —
+the file must start with `-- Scrum Open Assessment ...` and end with `END $$;`.
+
+## Schema constraints
+
+- Table `public.questions` columns: id, exam, stem, explanation_en,
+  explanation_vi, tags (text[]), term_refs (uuid[]), source, quality, owner_id.
+- Table `public.question_options` columns: id, question_id, text, correct,
+  sort_order.
+- `exam` MUST be 'PSM-I' (or 'PSPO-I' if the source is PSPO Open).
+- `quality` is always 'trusted' for scrum.org content.
+- `source` is always 'Scrum Open Assessment'.
+- `owner_id` is omitted (defaults to NULL → public/shared question).
+- Every question MUST be tagged with the pool tag (see below).
+
+## Pool tag
+
+Ask the user: "Which pool tag should I use? (e.g., scrum-open-pool-3)"
+Default to `scrum-open-pool-3` if no answer. Put this tag in EVERY
+question's `tags` array as the LAST element.
+
+## Translation rules
+
+- `explanation_en` is the feedback paragraph, lightly edited for clarity
+  (1-3 sentences).
+- `explanation_vi` is a Vietnamese translation of the feedback.
+- Keep these terms in English (don't translate): Scrum, Sprint, Sprint Goal,
+  Product Owner, Scrum Master, Developers, Product Backlog, Sprint Backlog,
+  Increment, Definition of Done, Daily Scrum, Sprint Planning, Sprint Review,
+  Sprint Retrospective, Product Goal, Scrum Team, Scrum Guide.
+- Translate normal English (verbs, connectors, adjectives) into Vietnamese.
+
+## Correctness extraction
+
+Read the Feedback paragraph carefully:
+- Single-correct: identify the one option that matches the feedback.
+- Multi-select: identify N options where N = "two"/"three" from the header.
+- T/F: feedback states which answer is correct.
+- If feedback is ambiguous, ADD a comment `-- TODO: verify correct answer`
+  next to the option.
+
+## Tags
+
+In addition to the pool tag, add 2-4 topic tags per question, e.g.:
+  ['sprint-planning', 'timebox', 'scrum-open-pool-3']
+  ['scrum-master', 'daily-scrum', 'scrum-open-pool-3']
+  ['true-false', 'product-backlog', 'scrum-open-pool-3']
+Use kebab-case. Always include `'multi-select'` for choose-2/3 questions
+and `'true-false'` for T/F questions.
+
+## SQL escaping
+
+- Single quotes inside text → double them: `Sprint's` → `Sprint''s`.
+- Empty term_refs is `'{}'::uuid[]`.
+- Tag arrays use `ARRAY['a', 'b']` syntax.
+
+## File template (FILL IN THE BLANKS — DO NOT change structure)
+
+    -- Scrum Open Assessment — Pool {{N}} ({{COUNT}} questions, {{EXAM}})
+    -- Idempotent: re-running this file removes Pool {{N}} questions (by tag)
+    -- and re-inserts. Other pools are NOT affected.
+    -- Run via Supabase SQL Editor or `psql -f`.
+
+    DELETE FROM public.questions
+      WHERE source = 'Scrum Open Assessment'
+        AND owner_id IS NULL
+        AND 'scrum-open-pool-{{N}}' = ANY(tags);
+
+    DO $$ DECLARE
+      q1  uuid; q2  uuid; q3  uuid; ... q{{COUNT}} uuid;
+    BEGIN
+      q1  := gen_random_uuid(); q2  := gen_random_uuid(); ...
+
+      -- ────── Questions ──────
+      INSERT INTO public.questions
+        (id, exam, stem, explanation_en, explanation_vi, tags, term_refs, source, quality)
+      VALUES
+        -- 1
+        (q1, '{{EXAM}}',
+         '{{STEM_1}}',
+         '{{EXPLAIN_EN_1}}',
+         '{{EXPLAIN_VI_1}}',
+         ARRAY[{{TAGS_1}}, 'scrum-open-pool-{{N}}'], '{}'::uuid[],
+         'Scrum Open Assessment', 'trusted'),
+
+        -- 2 ... and so on until question {{COUNT}}, last row ends with `);`
+
+      -- ────── Options ──────
+
+      -- Q1: <short label>
+      INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+        (gen_random_uuid(), q1, '{{OPT_1A}}', {{TRUE_OR_FALSE}}, 0),
+        (gen_random_uuid(), q1, '{{OPT_1B}}', {{TRUE_OR_FALSE}}, 1),
+        ...;
+
+      -- Q2 ... and so on
+
+    END $$;
+
+# WORKED EXAMPLE (input → output, abbreviated to 2 questions)
+
+INPUT:
+    Question 1 of 2
+
+    What is the maximum length of a Sprint?
+
+    **(choose the best answer)**
+
+    A. Two weeks
+    B. One month
+    C. Six weeks
+    D. There is no maximum
+
+    Feedback
+    The Scrum Guide states Sprints are one month or less.
+
+    Question 2 of 2
+
+    **True or False:** Scrum has a role called "project manager."
+
+    Feedback
+    A Scrum Team has a Scrum Master, a Product Owner and Developers. There
+    is no project manager role.
+
+OUTPUT (pool 9, exam PSM-I):
+
+    -- Scrum Open Assessment — Pool 9 (2 questions, PSM-I)
+    -- ... [header comments] ...
+
+    DELETE FROM public.questions
+      WHERE source = 'Scrum Open Assessment'
+        AND owner_id IS NULL
+        AND 'scrum-open-pool-9' = ANY(tags);
+
+    DO $$ DECLARE
+      q1 uuid; q2 uuid;
+    BEGIN
+      q1 := gen_random_uuid(); q2 := gen_random_uuid();
+
+      INSERT INTO public.questions
+        (id, exam, stem, explanation_en, explanation_vi, tags, term_refs, source, quality)
+      VALUES
+        (q1, 'PSM-I',
+         'What is the maximum length of a Sprint?',
+         'The Scrum Guide states Sprints are one month or less.',
+         'Scrum Guide quy định Sprint có thời gian tối đa là một tháng.',
+         ARRAY['sprint', 'timebox', 'scrum-open-pool-9'], '{}'::uuid[],
+         'Scrum Open Assessment', 'trusted'),
+
+        (q2, 'PSM-I',
+         'True or False: Scrum has a role called "project manager."',
+         'A Scrum Team has a Scrum Master, a Product Owner and Developers. There is no project manager role.',
+         'Scrum Team gồm Scrum Master, Product Owner và Developers. Không có vai trò project manager.',
+         ARRAY['true-false', 'roles', 'scrum-open-pool-9'], '{}'::uuid[],
+         'Scrum Open Assessment', 'trusted');
+
+      -- Q1: Sprint length
+      INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+        (gen_random_uuid(), q1, 'Two weeks', false, 0),
+        (gen_random_uuid(), q1, 'One month', true, 1),
+        (gen_random_uuid(), q1, 'Six weeks', false, 2),
+        (gen_random_uuid(), q1, 'There is no maximum', false, 3);
+
+      -- Q2: Scrum has project manager (T/F)
+      INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
+        (gen_random_uuid(), q2, 'True', false, 0),
+        (gen_random_uuid(), q2, 'False', true, 1);
+
+    END $$;
+
+# YOUR TASK
+Below the line `<<INPUT_START>>` is the user's crawled markdown. Convert it
+to a SQL seed file following ALL rules above. Return ONLY the SQL — no
+explanation, no markdown fences, no preamble.
+
+If the pool number is not obvious, ask the user before generating.
+
+<<INPUT_START>>
+[PASTE YOUR CRAWLED MARKDOWN HERE]
+```
+
+---
+
+## Post-generation checklist
+
+Sau khi AI trả file, làm 5 việc:
+
+1. **Đếm câu**: số lượng `(q1,` `(q2,` … phải khớp `q{N}` trong DECLARE.
+2. **Đếm correct**: tổng số `, true,` phải = (số câu single) × 1 + (số câu
+   multi-2) × 2 + (số câu multi-3) × 3.
+3. **Multi-select sanity**: với câu "choose the best N answers", đếm `, true,`
+   trong block options của câu đó phải = N.
+4. **T/F sanity**: câu T/F chỉ có đúng 2 options (`True` và `False`), 1 correct.
+5. **Chạy thử trên 1 DB rỗng**: nếu fail vì `questions_stem_unique`, lấy stem
+   trong error message, xóa câu đó khỏi seed mới, chạy lại.
+
+## Nếu AI làm hỏng
+
+Common failure modes:
+- **Quote không escape**: AI quên double single quote → SQL parse error. Fix
+  bằng prompt phụ: "Re-emit, ensuring all single quotes inside strings are
+  doubled."
+- **Multi-select đếm sai**: AI chọn 3 đáp án cho câu choose-2. Fix bằng
+  prompt phụ: "Re-check Q{N}: the header says choose {N}, but you marked
+  {M} options as correct."
+- **Quên tag pool**: prompt phụ: "Every question must have
+  'scrum-open-pool-{{N}}' as the last tag in its ARRAY."
+- **Dịch quá tay** (dịch cả "Scrum"/"Sprint"): prompt phụ: "Keep Scrum
+  terminology in English; only translate connectives and verbs."

--- a/docs/quiz-import-prompt.md
+++ b/docs/quiz-import-prompt.md
@@ -114,9 +114,15 @@ and `'true-false'` for T/F questions.
         AND 'scrum-open-pool-{{N}}' = ANY(tags);
 
     DO $$ DECLARE
-      q1  uuid; q2  uuid; q3  uuid; ... q{{COUNT}} uuid;
+      -- Static UUIDs: MUST be hardcoded, not generated at runtime.
+      -- Re-running the seed preserves public.progress records keyed to these IDs.
+      -- Generate a fresh batch once with:
+      --   python3 -c "import uuid; [print(str(uuid.uuid4())) for _ in range({{COUNT}})]"
+      q1  uuid := '{{UUID_1}}';
+      q2  uuid := '{{UUID_2}}';
+      ...
+      q{{COUNT}} uuid := '{{UUID_COUNT}}';
     BEGIN
-      q1  := gen_random_uuid(); q2  := gen_random_uuid(); ...
 
       -- ────── Questions ──────
       INSERT INTO public.questions
@@ -180,9 +186,10 @@ OUTPUT (pool 9, exam PSM-I):
         AND 'scrum-open-pool-9' = ANY(tags);
 
     DO $$ DECLARE
-      q1 uuid; q2 uuid;
+      -- Static UUIDs: hardcoded for idempotency (preserves progress records on re-run).
+      q1 uuid := 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      q2 uuid := 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
     BEGIN
-      q1 := gen_random_uuid(); q2 := gen_random_uuid();
 
       INSERT INTO public.questions
         (id, exam, stem, explanation_en, explanation_vi, tags, term_refs, source, quality)

--- a/supabase/migrations/006_normalize_scrum_open.sql
+++ b/supabase/migrations/006_normalize_scrum_open.sql
@@ -1,0 +1,23 @@
+-- ============================================================
+-- Normalize Scrum Open questions
+-- 1) Tag legacy Pool 1 rows that were seeded before pool tags existed.
+-- 2) Add UNIQUE(stem) safety net to prevent future duplicates.
+--
+-- Run this once after merging the dedupe PR.
+-- ============================================================
+
+-- Step 1: tag legacy Pool 1 rows.
+-- Without this, the DELETE clause at the top of seed_scrum_open.sql would
+-- not match these rows; re-running that seed would then collide with the
+-- UNIQUE constraint added in step 2.
+UPDATE public.questions
+SET tags = array_append(tags, 'scrum-open-pool-1')
+WHERE source = 'Scrum Open Assessment'
+  AND owner_id IS NULL
+  AND NOT ('scrum-open-pool-1' = ANY(tags));
+
+-- Step 2: enforce unique stems at the database level.
+-- Future seeds with overlapping stems will fail loudly with the offending
+-- text in the error message, instead of silently duplicating.
+ALTER TABLE public.questions
+  ADD CONSTRAINT questions_stem_unique UNIQUE (stem);

--- a/supabase/migrations/006_unique_question_stem.sql
+++ b/supabase/migrations/006_unique_question_stem.sql
@@ -1,8 +1,0 @@
--- ============================================================
--- Unique constraint on question stem
--- Prevents inserting duplicate questions when seed files are
--- re-run or new pools overlap with existing ones.
--- ============================================================
-
-ALTER TABLE public.questions
-  ADD CONSTRAINT questions_stem_unique UNIQUE (stem);

--- a/supabase/migrations/006_unique_question_stem.sql
+++ b/supabase/migrations/006_unique_question_stem.sql
@@ -1,0 +1,8 @@
+-- ============================================================
+-- Unique constraint on question stem
+-- Prevents inserting duplicate questions when seed files are
+-- re-run or new pools overlap with existing ones.
+-- ============================================================
+
+ALTER TABLE public.questions
+  ADD CONSTRAINT questions_stem_unique UNIQUE (stem);

--- a/supabase/seed_scrum_open.sql
+++ b/supabase/seed_scrum_open.sql
@@ -1,6 +1,14 @@
--- Scrum Open Assessment — 30 representative questions (PSM-I)
+-- Scrum Open Assessment — Pool 1 (30 representative PSM-I questions)
+-- Idempotent: re-running this file removes Pool 1 questions (by tag) and re-inserts.
+-- Pool 2 questions (seed_scrum_open_v2.sql) are NOT affected.
 -- Run via: psql <connection-string> -f supabase/seed_scrum_open.sql
 --       or paste into Supabase Studio → SQL Editor.
+
+-- ── Idempotency: drop prior Pool 1 rows; options cascade via FK ─────
+DELETE FROM public.questions
+  WHERE source = 'Scrum Open Assessment'
+    AND owner_id IS NULL
+    AND 'scrum-open-pool-1' = ANY(tags);
 
 DO $$ DECLARE
   q1  uuid; q2  uuid; q3  uuid; q4  uuid; q5  uuid;
@@ -32,210 +40,210 @@ BEGIN
      'What is the maximum length of a Sprint?',
      'The Scrum Guide states Sprints are one month or less. No Sprint may be longer than one month. When a Sprint''s horizon is too long, the Sprint Goal may become invalid and complexity may rise.',
      'Scrum Guide quy định Sprint có thời gian tối đa là một tháng. Sprint dài hơn có thể khiến Sprint Goal mất giá trị và rủi ro gia tăng.',
-     ARRAY['sprint', 'timebox'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint', 'timebox', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 2
     (q2, 'PSM-I',
      'Who is accountable for maximizing the value of the product resulting from the work of the Scrum Team?',
      'The Product Owner is accountable for maximizing the value of the product resulting from the work of the Scrum Team. How this is done may vary widely across organizations, Scrum Teams, and individuals.',
      'Product Owner chịu trách nhiệm tối đa hóa giá trị của sản phẩm từ công việc của Scrum Team. Cách thực hiện có thể khác nhau tùy tổ chức.',
-     ARRAY['product-owner', 'accountability'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['product-owner', 'accountability', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 3
     (q3, 'PSM-I',
      'What is the timebox for the Daily Scrum?',
      'The Daily Scrum is a 15-minute event for the Developers of the Scrum Team. To reduce complexity, it is held at the same time and place every working day of the Sprint.',
      'Daily Scrum là sự kiện 15 phút dành cho Developers. Được tổ chức cùng giờ, cùng địa điểm mỗi ngày làm việc trong Sprint để giảm phức tạp.',
-     ARRAY['daily-scrum', 'timebox'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['daily-scrum', 'timebox', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 4
     (q4, 'PSM-I',
      'Who has the authority to cancel a Sprint?',
      'Only the Product Owner has the authority to cancel a Sprint. A Sprint would be cancelled if the Sprint Goal becomes obsolete. This is a rare occurrence.',
      'Chỉ Product Owner mới có quyền hủy Sprint. Sprint bị hủy khi Sprint Goal trở nên lỗi thời. Đây là trường hợp hiếm gặp.',
-     ARRAY['sprint', 'product-owner', 'cancellation'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint', 'product-owner', 'cancellation', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 5
     (q5, 'PSM-I',
      'Which three pillars uphold every implementation of empirical process control?',
      'The three pillars of empiricism are Transparency, Inspection, and Adaptation. Scrum combines these pillars to make decisions based on what is observed rather than speculation.',
      'Ba trụ cột của chủ nghĩa kinh nghiệm trong Scrum là Minh bạch (Transparency), Thanh tra (Inspection) và Thích nghi (Adaptation). Đây là nền tảng cho mọi quyết định dựa trên thực tế quan sát được.',
-     ARRAY['empiricism', 'transparency', 'inspection', 'adaptation'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['empiricism', 'transparency', 'inspection', 'adaptation', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 6
     (q6, 'PSM-I',
      'Which statement about the Increment is correct?',
      'Multiple Increments may be created within a Sprint. The sum of the Increments is presented at the Sprint Review, supporting empiricism. The Product Owner may decide to release any Increment before the Sprint ends.',
      'Nhiều Increment có thể được tạo ra trong một Sprint. Product Owner có thể quyết định phát hành bất kỳ Increment nào trước khi Sprint kết thúc.',
-     ARRAY['increment', 'sprint'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['increment', 'sprint', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 7
     (q7, 'PSM-I',
      'What is the maximum timebox for Sprint Planning for a one-month Sprint?',
      'Sprint Planning is timeboxed to a maximum of 8 hours for a one-month Sprint. For shorter Sprints, the event is usually shorter.',
      'Sprint Planning được giới hạn tối đa 8 giờ cho Sprint một tháng. Sprint ngắn hơn thường có Sprint Planning ngắn hơn tương ứng.',
-     ARRAY['sprint-planning', 'timebox'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint-planning', 'timebox', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 8
     (q8, 'PSM-I',
      'What is the commitment for the Sprint Backlog?',
      'The Sprint Goal is the commitment for the Sprint Backlog. The Sprint Goal is the single objective for the Sprint and provides flexibility to Developers while maintaining focus.',
      'Sprint Goal là cam kết gắn với Sprint Backlog. Sprint Goal tạo ra sự linh hoạt cho Developers trong khi vẫn duy trì trọng tâm nhất quán.',
-     ARRAY['sprint-backlog', 'sprint-goal', 'commitment'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint-backlog', 'sprint-goal', 'commitment', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 9
     (q9, 'PSM-I',
      'Which of the following best describes the Scrum Master''s role?',
      'The Scrum Master is accountable for establishing Scrum and coaching the Scrum Team in self-management and cross-functionality. The Scrum Master is a servant leader, not a manager who assigns work.',
      'Scrum Master chịu trách nhiệm thiết lập Scrum và huấn luyện Scrum Team về tự quản lý và đa chức năng. Scrum Master là người lãnh đạo phục vụ, không phải quản lý phân công công việc.',
-     ARRAY['scrum-master', 'servant-leader'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['scrum-master', 'servant-leader', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 10
     (q10, 'PSM-I',
      'Who are the members of a Scrum Team?',
      'A Scrum Team consists of one Scrum Master, one Product Owner, and Developers. There are no sub-teams or hierarchies within a Scrum Team; it is a cohesive unit of professionals.',
      'Scrum Team gồm một Scrum Master, một Product Owner và các Developers. Không có sub-team hay hệ thống phân cấp bên trong Scrum Team.',
-     ARRAY['scrum-team'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['scrum-team', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 11
     (q11, 'PSM-I',
      'What is the recommended size for a Scrum Team?',
      'The Scrum Team should be small enough to remain nimble and large enough to complete significant work within a Sprint — typically 10 or fewer people. If teams become too large, they should consider reorganizing into multiple cohesive Scrum Teams.',
      'Scrum Team đủ nhỏ để linh hoạt và đủ lớn để hoàn thành công việc đáng kể trong một Sprint — thường từ 10 người trở xuống.',
-     ARRAY['scrum-team', 'team-size'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['scrum-team', 'team-size', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 12
     (q12, 'PSM-I',
      'What is the maximum timebox for the Sprint Review for a one-month Sprint?',
      'The Sprint Review is timeboxed to a maximum of 4 hours for a one-month Sprint. For shorter Sprints, the event is usually shorter.',
      'Sprint Review được giới hạn tối đa 4 giờ cho Sprint một tháng. Sprint ngắn hơn thường có Sprint Review ngắn hơn tương ứng.',
-     ARRAY['sprint-review', 'timebox'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint-review', 'timebox', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 13
     (q13, 'PSM-I',
      'What is the maximum timebox for the Sprint Retrospective for a one-month Sprint?',
      'The Sprint Retrospective is timeboxed to a maximum of 3 hours for a one-month Sprint. The Scrum Team inspects how the last Sprint went with regards to individuals, interactions, processes, tools, and the Definition of Done.',
      'Sprint Retrospective được giới hạn tối đa 3 giờ cho Sprint một tháng. Scrum Team kiểm tra cách Sprint vừa diễn ra liên quan đến con người, tương tác, quy trình và công cụ.',
-     ARRAY['sprint-retrospective', 'timebox'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint-retrospective', 'timebox', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 14
     (q14, 'PSM-I',
      'Who is responsible for creating the Definition of Done when there is no existing organizational standard?',
      'If the Definition of Done is not a standard of the organization, the Developers of the Scrum Team must create a Definition of Done appropriate for the product. The Scrum Master ensures the team has one.',
      'Nếu tổ chức không có tiêu chuẩn Definition of Done, các Developers của Scrum Team phải tự tạo DoD phù hợp với sản phẩm của họ.',
-     ARRAY['definition-of-done'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['definition-of-done', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 15
     (q15, 'PSM-I',
      'Which of the following is one of Scrum''s three pillars of empiricism but NOT one of the five Scrum values?',
      'The three pillars are Transparency, Inspection, and Adaptation. The five Scrum values are: Commitment, Focus, Openness, Respect, and Courage. Transparency is a pillar, not a value.',
      'Ba trụ cột là: Transparency, Inspection, Adaptation. Năm giá trị Scrum là: Commitment, Focus, Openness, Respect, Courage. Transparency là trụ cột, không phải giá trị.',
-     ARRAY['empiricism', 'scrum-values'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['empiricism', 'scrum-values', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 16
     (q16, 'PSM-I',
      'When multiple Scrum Teams are working on the same product, how many Product Backlogs should there be?',
      'There is one Product Backlog per product, regardless of how many Scrum Teams work on it. Having one Product Backlog ensures a single source of truth for priorities and goals.',
      'Chỉ có một Product Backlog cho mỗi sản phẩm, dù có bao nhiêu Scrum Team cùng làm việc. Điều này đảm bảo có một nguồn thông tin duy nhất về thứ tự ưu tiên.',
-     ARRAY['product-backlog'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['product-backlog', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 17
     (q17, 'PSM-I',
      'Who is responsible for sizing (estimating) Product Backlog items?',
      'The Developers who will be doing the work are responsible for the sizing of Product Backlog items. The Product Owner may influence by helping Developers understand and select trade-offs.',
      'Các Developers thực hiện công việc chịu trách nhiệm ước lượng kích thước của các Product Backlog item. Product Owner có thể hỗ trợ bằng cách làm rõ yêu cầu và trade-off.',
-     ARRAY['product-backlog', 'estimation'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['product-backlog', 'estimation', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 18
     (q18, 'PSM-I',
      'When is the Sprint Goal created?',
      'The Sprint Goal is created during Sprint Planning. It is the single objective for the Sprint and is crafted collaboratively by the Scrum Team. After Sprint Planning, the Developers inform the Product Owner of the Sprint Goal.',
      'Sprint Goal được tạo ra trong quá trình Sprint Planning. Đây là mục tiêu duy nhất cho Sprint, được tạo ra cùng nhau bởi Scrum Team.',
-     ARRAY['sprint-goal', 'sprint-planning'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint-goal', 'sprint-planning', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 19
     (q19, 'PSM-I',
      'What is the primary purpose of the Daily Scrum?',
      'The Daily Scrum''s purpose is to inspect progress toward the Sprint Goal and adapt the Sprint Backlog as necessary, adjusting the upcoming planned work. It is not a status meeting for management.',
      'Mục đích của Daily Scrum là thanh tra tiến độ hướng tới Sprint Goal và thích nghi Sprint Backlog nếu cần. Đây không phải là cuộc họp báo cáo cho ban quản lý.',
-     ARRAY['daily-scrum', 'sprint-goal'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['daily-scrum', 'sprint-goal', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 20
     (q20, 'PSM-I',
      'Which description best fits the Scrum Master role?',
      'The Scrum Master is a servant leader who serves the Scrum Team and the larger organization. They help everyone understand Scrum theory and practice, and remove impediments to the Scrum Team''s progress.',
      'Scrum Master là người lãnh đạo phục vụ cho Scrum Team và tổ chức. Họ giúp mọi người hiểu lý thuyết và thực hành Scrum, đồng thời loại bỏ các trở ngại cho Scrum Team.',
-     ARRAY['scrum-master', 'servant-leader'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['scrum-master', 'servant-leader', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 21
     (q21, 'PSM-I',
      'What happens to incomplete Product Backlog items at the end of a Sprint?',
      'Incomplete Product Backlog items are returned to the Product Backlog. They are re-estimated and re-prioritized by the Product Owner in the next refinement cycle. The Sprint is NOT extended.',
      'Các Product Backlog item chưa hoàn thành được trả lại Product Backlog. Product Owner sẽ ước lượng lại và sắp xếp thứ tự ưu tiên trong chu kỳ refinement tiếp theo. Sprint không được kéo dài.',
-     ARRAY['sprint', 'product-backlog'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint', 'product-backlog', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 22
     (q22, 'PSM-I',
      'Which statement about the Sprint Backlog is correct?',
      'The Sprint Backlog is updated throughout the Sprint as Developers learn more. Only Developers can change the Sprint Backlog; the Product Owner does not modify it unilaterally.',
      'Sprint Backlog được cập nhật liên tục trong suốt Sprint khi Developers học được nhiều hơn. Chỉ Developers mới có thể thay đổi Sprint Backlog.',
-     ARRAY['sprint-backlog'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint-backlog', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 23
     (q23, 'PSM-I',
      'What best describes Product Backlog refinement?',
      'Product Backlog refinement is the act of breaking down and further defining Product Backlog items into smaller, more precise items. This is an ongoing activity in which the Product Owner and the Scrum Team collaborate.',
      'Product Backlog refinement là hoạt động phân tách và làm rõ thêm các Product Backlog item thành các mục nhỏ hơn, chính xác hơn. Đây là hoạt động liên tục giữa Product Owner và Scrum Team.',
-     ARRAY['product-backlog', 'refinement'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['product-backlog', 'refinement', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 24
     (q24, 'PSM-I',
      'What is the Product Goal?',
      'The Product Goal describes a future state of the product which can serve as a target for the Scrum Team to plan against. It is the commitment for the Product Backlog and represents the long-term objective.',
      'Product Goal mô tả trạng thái tương lai của sản phẩm mà Scrum Team hướng đến. Đây là cam kết của Product Backlog và là mục tiêu dài hạn cho Scrum Team.',
-     ARRAY['product-goal', 'product-backlog'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['product-goal', 'product-backlog', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 25
     (q25, 'PSM-I',
      'Which statement best describes an Increment?',
      'An Increment is a concrete stepping stone toward the Product Goal. Each Increment is additive to all prior Increments and thoroughly verified, ensuring that all Increments work together. An Increment must be usable.',
      'Increment là một bước cụ thể hướng tới Product Goal. Mỗi Increment bổ sung cho tất cả các Increment trước đó và được xác minh kỹ lưỡng. Increment phải có thể sử dụng được.',
-     ARRAY['increment', 'product-goal'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['increment', 'product-goal', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 26
     (q26, 'PSM-I',
      'Which of the following is the complete set of Scrum values?',
      'The five Scrum values are: Commitment, Focus, Openness, Respect, and Courage. When these values are embodied and lived by the Scrum Team, the Scrum pillars of Transparency, Inspection, and Adaptation come to life.',
      'Năm giá trị Scrum là: Commitment (Cam kết), Focus (Tập trung), Openness (Cởi mở), Respect (Tôn trọng) và Courage (Dũng cảm). Những giá trị này là nền tảng văn hóa của Scrum.',
-     ARRAY['scrum-values'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['scrum-values', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 27
     (q27, 'PSM-I',
      'What is the purpose of the Sprint Review?',
      'The Sprint Review''s purpose is to inspect the outcome of the Sprint and determine future adaptations. The Scrum Team presents the results to key stakeholders and discusses progress toward the Product Goal. The Product Backlog may be adjusted.',
      'Mục đích của Sprint Review là thanh tra kết quả của Sprint và xác định hướng thích nghi tiếp theo. Scrum Team trình bày kết quả cho các stakeholders chính và thảo luận về tiến độ hướng tới Product Goal.',
-     ARRAY['sprint-review', 'product-backlog'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint-review', 'product-backlog', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 28
     (q28, 'PSM-I',
      'What is the primary purpose of the Sprint Retrospective?',
      'The purpose of the Sprint Retrospective is to plan ways to increase quality and effectiveness. The Scrum Team inspects how the last Sprint went and identifies the most helpful improvements to implement next Sprint.',
      'Mục đích của Sprint Retrospective là lên kế hoạch cải thiện chất lượng và hiệu quả. Scrum Team kiểm tra Sprint vừa qua và xác định các cải tiến hữu ích nhất để áp dụng vào Sprint tiếp theo.',
-     ARRAY['sprint-retrospective'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint-retrospective', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 29
     (q29, 'PSM-I',
      'What does the Definition of Done provide for the Scrum Team?',
      'The Definition of Done creates transparency by providing everyone a shared understanding of what work is considered complete. If a Product Backlog item does not meet the DoD, it cannot be released or presented at the Sprint Review.',
      'Definition of Done tạo ra sự minh bạch bằng cách cung cấp hiểu biết chung về thế nào là "hoàn thành". Nếu một Product Backlog item không đáp ứng DoD, nó không thể phát hành hoặc trình bày tại Sprint Review.',
-     ARRAY['definition-of-done', 'transparency'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['definition-of-done', 'transparency', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 30
     (q30, 'PSM-I',
      'Which statement best describes Scrum?',
      'Scrum is a lightweight framework that helps people, teams, and organizations generate value through adaptive solutions for complex problems. It is intentionally incomplete, only defining the parts required to implement Scrum theory.',
      'Scrum là một framework nhẹ giúp mọi người, nhóm và tổ chức tạo ra giá trị thông qua các giải pháp thích nghi cho các vấn đề phức tạp. Scrum cố tình không đầy đủ, chỉ định nghĩa những phần cần thiết.',
-     ARRAY['scrum', 'framework'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted');
+     ARRAY['scrum', 'framework', 'scrum-open-pool-1'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted');
 
   -- ────────────────────────────────────────────────────────────
   -- Options

--- a/supabase/seed_scrum_open.sql
+++ b/supabase/seed_scrum_open.sql
@@ -11,23 +11,38 @@ DELETE FROM public.questions
     AND 'scrum-open-pool-1' = ANY(tags);
 
 DO $$ DECLARE
-  q1  uuid; q2  uuid; q3  uuid; q4  uuid; q5  uuid;
-  q6  uuid; q7  uuid; q8  uuid; q9  uuid; q10 uuid;
-  q11 uuid; q12 uuid; q13 uuid; q14 uuid; q15 uuid;
-  q16 uuid; q17 uuid; q18 uuid; q19 uuid; q20 uuid;
-  q21 uuid; q22 uuid; q23 uuid; q24 uuid; q25 uuid;
-  q26 uuid; q27 uuid; q28 uuid; q29 uuid; q30 uuid;
+  -- Static UUIDs: stable across re-runs so public.progress records are preserved.
+  q1   uuid := 'e9d04f0d-7221-4899-9efb-e69b6492462a';
+  q2   uuid := 'a0a21297-9764-48e7-a4df-e4901d53f56f';
+  q3   uuid := '955086b5-c12c-4388-b5ba-4a3c3a2cb7b6';
+  q4   uuid := '2e856166-490b-4758-a30b-980b9ac9dc97';
+  q5   uuid := 'fa1c4e2a-b834-4ee4-ae79-7c469888e700';
+  q6   uuid := '39365769-f4ac-4941-84bc-7eec392d805e';
+  q7   uuid := 'ca56a4a2-8339-4554-b4c0-5950af46e384';
+  q8   uuid := '7284e4ac-50ac-4903-a5d2-fd4c8bdd011a';
+  q9   uuid := '23ab812c-0954-45f2-9e6f-e6efc7bfa570';
+  q10  uuid := '4bb8ef34-292b-4e7b-bef9-2d271fe1ce25';
+  q11  uuid := '9ee88992-e716-474b-b478-b93ec4d3f04b';
+  q12  uuid := '79e6aad5-a46c-4157-86c9-1c309e0628e0';
+  q13  uuid := '07482980-4ad9-4436-8a39-acc6e7b698ef';
+  q14  uuid := '1ce52192-dfbd-4a1f-bcc5-fa19fc3b608d';
+  q15  uuid := 'd23c700a-94ad-4fdd-8ee2-45d5b8b74087';
+  q16  uuid := 'dea413a3-21b9-4a0d-a7a5-3a89ede00caa';
+  q17  uuid := '4ff45f1a-5d64-4672-81de-9040829a6555';
+  q18  uuid := '3d4555dc-a1b3-4a02-b9dc-dce7bc108847';
+  q19  uuid := '7f998de1-b91e-4190-90ba-88747345ee11';
+  q20  uuid := '7f85b5fe-e652-4650-bae6-c56c56e29ee8';
+  q21  uuid := '2969479c-d6d2-486a-8417-00ae43675bc4';
+  q22  uuid := '75279768-f42c-4e82-8a25-52e3e4fb8bf9';
+  q23  uuid := '370d625a-ce44-4660-8cfe-3f78872a4f34';
+  q24  uuid := 'c5950f1a-28d9-4132-acab-6bbb643ea735';
+  q25  uuid := 'e89966fb-fb81-4d6e-b06d-5ae1bed8739b';
+  q26  uuid := 'e8059a92-11f7-4d15-806d-208b24bcae08';
+  q27  uuid := '9c2182dd-2e83-4b98-bf24-ccd8620430af';
+  q28  uuid := '8514ce4e-b4ee-471a-afd9-90e23b9e0d5a';
+  q29  uuid := '87c870b1-0baa-4f61-bfcc-e16206aff70b';
+  q30  uuid := 'b1910162-3582-49dd-8cb1-b6875db0fc2c';
 BEGIN
-  q1  := gen_random_uuid(); q2  := gen_random_uuid(); q3  := gen_random_uuid();
-  q4  := gen_random_uuid(); q5  := gen_random_uuid(); q6  := gen_random_uuid();
-  q7  := gen_random_uuid(); q8  := gen_random_uuid(); q9  := gen_random_uuid();
-  q10 := gen_random_uuid(); q11 := gen_random_uuid(); q12 := gen_random_uuid();
-  q13 := gen_random_uuid(); q14 := gen_random_uuid(); q15 := gen_random_uuid();
-  q16 := gen_random_uuid(); q17 := gen_random_uuid(); q18 := gen_random_uuid();
-  q19 := gen_random_uuid(); q20 := gen_random_uuid(); q21 := gen_random_uuid();
-  q22 := gen_random_uuid(); q23 := gen_random_uuid(); q24 := gen_random_uuid();
-  q25 := gen_random_uuid(); q26 := gen_random_uuid(); q27 := gen_random_uuid();
-  q28 := gen_random_uuid(); q29 := gen_random_uuid(); q30 := gen_random_uuid();
 
   -- ────────────────────────────────────────────────────────────
   -- Questions

--- a/supabase/seed_scrum_open_v2.sql
+++ b/supabase/seed_scrum_open_v2.sql
@@ -1,8 +1,16 @@
 -- Scrum Open Assessment — Pool 2 (30 questions, PSM-I)
 -- Complements supabase/seed_scrum_open.sql with a different question pool
 -- (same Scrum.org Open Assessment source, different sampled questions).
+-- Idempotent: re-running this file removes Pool 2 questions (by tag) and re-inserts.
+-- Pool 1 questions (seed_scrum_open.sql) are NOT affected.
 -- Run via: psql <connection-string> -f supabase/seed_scrum_open_v2.sql
 --       or paste into Supabase Studio → SQL Editor.
+
+-- ── Idempotency: drop prior Pool 2 rows; options cascade via FK ─────
+DELETE FROM public.questions
+  WHERE source = 'Scrum Open Assessment'
+    AND owner_id IS NULL
+    AND 'scrum-open-pool-2' = ANY(tags);
 
 DO $$ DECLARE
   q1  uuid; q2  uuid; q3  uuid; q4  uuid; q5  uuid;
@@ -34,210 +42,210 @@ BEGIN
      'When does a Developer become accountable for the value of a Product Backlog item selected for the Sprint?',
      'All members of the Scrum Team share in the accountability for creating value every Sprint. No individual Developer is singled out as accountable for an item''s value.',
      'Toàn bộ Scrum Team cùng chịu trách nhiệm tạo ra giá trị mỗi Sprint. Không một Developer riêng lẻ nào là người chịu trách nhiệm về giá trị của một Product Backlog item.',
-     ARRAY['scrum-team', 'accountability', 'value'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['scrum-team', 'accountability', 'value', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 2
     (q2, 'PSM-I',
      'The Developers should have all the skills needed to:',
      'The Developers are a group of professionals who do the work of delivering an Increment of done product at the end of each Sprint. As a team, Developers have all of the skills necessary to create a product Increment.',
      'Developers là nhóm chuyên gia có nhiệm vụ tạo ra Increment "done" mỗi Sprint. Cả nhóm phải có đầy đủ kỹ năng cần thiết để tạo ra Increment — bao gồm cả testing chuyên biệt.',
-     ARRAY['developers', 'cross-functional', 'increment'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['developers', 'cross-functional', 'increment', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 3
     (q3, 'PSM-I',
      'When should a Developer on a Scrum Team be replaced?',
      'Scrum Teams typically go through some steps before achieving a state of increased performance. Changing membership typically reduces cohesion, affecting performance and productivity in the short term.',
      'Thay đổi thành viên Scrum Team thường làm giảm sự gắn kết, ảnh hưởng ngắn hạn đến năng suất. Vẫn nên thay khi cần, nhưng phải tính đến tác động ngắn hạn này.',
-     ARRAY['scrum-team', 'team-stability'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['scrum-team', 'team-stability', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 4
     (q4, 'PSM-I',
      'Which of the following services is appropriate for a Scrum Master in regard to the Daily Scrum?',
      'The Scrum Master ensures that the Developers have the event, but the Developers are responsible for conducting the Daily Scrum. The Scrum Master teaches the Developers to keep the Daily Scrum within the 15-minute timebox.',
      'Scrum Master đảm bảo Developers có sự kiện Daily Scrum, nhưng chính Developers mới điều hành. Scrum Master dạy/huấn luyện Developers giữ Daily Scrum trong khung 15 phút — không phải dẫn dắt thảo luận hay đảm bảo trả lời "3 câu hỏi".',
-     ARRAY['scrum-master', 'daily-scrum', 'timebox'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['scrum-master', 'daily-scrum', 'timebox', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 5
     (q5, 'PSM-I',
      'Which statement best describes the Sprint Review?',
      'Every event in Scrum, besides the Sprint, which is a container for the other events, is an opportunity to Inspect and Adapt. The Sprint Review is when the Scrum Team and stakeholders inspect the outcome and figure out what to do next.',
      'Sprint Review là dịp Scrum Team và stakeholders cùng thanh tra kết quả của Sprint và quyết định hướng đi tiếp theo. Không phải cuộc demo cho cả tổ chức, cũng không phải cơ chế kiểm soát hoạt động của Developers.',
-     ARRAY['sprint-review', 'inspect-adapt', 'stakeholders'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint-review', 'inspect-adapt', 'stakeholders', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 6
     (q6, 'PSM-I',
      'Who creates the Definition of Done?',
      'If the Definition of Done for an Increment is part of the standards of the organization, all Scrum Teams must follow it as a minimum. If it is not an organizational standard, the Scrum Team must create a Definition of Done appropriate for the product.',
      'Nếu tổ chức có tiêu chuẩn Definition of Done, mọi Scrum Team phải tuân theo. Nếu không, chính Scrum Team phải tự tạo DoD phù hợp với sản phẩm của mình.',
-     ARRAY['definition-of-done', 'scrum-team'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['definition-of-done', 'scrum-team', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 7 (multi-select: choose 2)
     (q7, 'PSM-I',
      'What are two ways a Scrum Master serves to enable effective Scrum Teams? (choose the best two answers)',
      'The Scrum Master serves the Scrum Team in several ways. Facilitation and removing impediments are two key examples that directly enable team effectiveness.',
      'Scrum Master phục vụ Scrum Team theo nhiều cách. Hai ví dụ tiêu biểu giúp Team hiệu quả hơn: gỡ bỏ trở ngại (impediments) và tạo điều kiện (facilitate) cho việc ra quyết định của Developers.',
-     ARRAY['scrum-master', 'servant-leader', 'multi-select'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['scrum-master', 'servant-leader', 'multi-select', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 8
     (q8, 'PSM-I',
      'The timebox for the Sprint Planning event is?',
      'Sprint Planning is timeboxed to a maximum of eight hours for a one-month Sprint. For shorter Sprints, the event is usually shorter.',
      'Sprint Planning có timebox tối đa 8 giờ cho Sprint một tháng. Sprint ngắn hơn thì sự kiện này thường ngắn hơn tương ứng.',
-     ARRAY['sprint-planning', 'timebox'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint-planning', 'timebox', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 9
     (q9, 'PSM-I',
      'What is the main reason for the Scrum Master to be at the Daily Scrum?',
      'The Scrum Master only ensures that all Scrum events take place and are positive, productive, and kept within the timebox. They do not have to attend — only ensure the Developers have a Daily Scrum.',
      'Scrum Master chỉ đảm bảo các sự kiện Scrum diễn ra, tích cực và đúng timebox. Họ KHÔNG bắt buộc phải có mặt tại Daily Scrum — chỉ cần đảm bảo Developers có sự kiện này.',
-     ARRAY['scrum-master', 'daily-scrum'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['scrum-master', 'daily-scrum', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 10
     (q10, 'PSM-I',
      'What is the typical size for a Scrum Team?',
      'A Scrum Team is small enough to remain nimble and large enough to complete significant work within a Sprint, typically 10 or fewer people. Generally smaller teams communicate better and are more productive.',
      'Scrum Team đủ nhỏ để linh hoạt nhưng đủ lớn để hoàn thành công việc đáng kể trong một Sprint — thường từ 10 người trở xuống. Nhóm nhỏ thường giao tiếp tốt hơn và năng suất hơn.',
-     ARRAY['scrum-team', 'team-size'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['scrum-team', 'team-size', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 11 (true/false)
     (q11, 'PSM-I',
      'True or False: Scrum has a role called "project manager."',
      'A Scrum Team has a Scrum Master, a Product Owner and Developers. As a whole they have all controls needed. There is no "project manager" role in Scrum.',
      'Scrum Team chỉ gồm Scrum Master, Product Owner và Developers. Cả nhóm có đủ quyền kiểm soát cần thiết. Scrum KHÔNG có vai trò "project manager".',
-     ARRAY['scrum-team', 'roles', 'true-false'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['scrum-team', 'roles', 'true-false', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 12 (multi-select: choose 3)
     (q12, 'PSM-I',
      'Who is on the Scrum Team? (choose the best three answers)',
      'The Scrum Team consists of the Scrum Master, the Product Owner and Developers. The Scrum Team is a cohesive unit of professionals focused on one objective at a time, the Product Goal.',
      'Scrum Team bao gồm Scrum Master, Product Owner và Developers. Đây là một đơn vị gắn kết của các chuyên gia, tập trung vào một mục tiêu duy nhất tại một thời điểm — Product Goal.',
-     ARRAY['scrum-team', 'roles', 'multi-select'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['scrum-team', 'roles', 'multi-select', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 13
     (q13, 'PSM-I',
      'What does it mean to say that an event has a timebox?',
      'Timeboxed events are events that have a maximum duration. The event must end by that maximum, regardless of whether all participants feel "done."',
      'Sự kiện có timebox nghĩa là có thời lượng TỐI ĐA. Sự kiện phải kết thúc trong khung thời gian này, bất kể người tham gia có thấy "xong" hay chưa.',
-     ARRAY['timebox', 'events'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['timebox', 'events', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 14
     (q14, 'PSM-I',
      'Which statement best describes a Product Owner''s responsibility?',
      'The Product Owner is accountable for maximizing the value of the product and the work of the Scrum Team.',
      'Product Owner chịu trách nhiệm tối đa hóa giá trị của sản phẩm và công việc của Scrum Team. KHÔNG phải chỉ đạo Developers hay quản lý dự án theo cam kết với stakeholders.',
-     ARRAY['product-owner', 'accountability', 'value'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['product-owner', 'accountability', 'value', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 15 (multi-select: choose 3)
     (q15, 'PSM-I',
      'A Scrum Team consists of the following: (choose the best three answers)',
      'The Scrum Team consists of one Scrum Master, one Product Owner, and Developers. Customers and users are stakeholders, not members of the Scrum Team.',
      'Scrum Team gồm một Scrum Master, một Product Owner và các Developers. Khách hàng và người dùng là stakeholders, KHÔNG phải thành viên Scrum Team.',
-     ARRAY['scrum-team', 'roles', 'multi-select'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['scrum-team', 'roles', 'multi-select', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 16 (true/false)
     (q16, 'PSM-I',
      'True or False: The Scrum Team must choose at least one high priority process improvement item, identified during the Sprint Retrospective, and place it in the Sprint Backlog.',
      'An earlier version of the Scrum Guide prescribed this practice, but it was removed in the 2020 update because it was felt to be too prescriptive. It may still be valuable, but is no longer prescribed.',
      'Phiên bản Scrum Guide trước đây có yêu cầu này, nhưng bản 2020 đã loại bỏ vì cho rằng quá quy định cụ thể. Thực hành này vẫn có thể hữu ích nhưng không còn bắt buộc.',
-     ARRAY['sprint-retrospective', 'scrum-guide-2020', 'true-false'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint-retrospective', 'scrum-guide-2020', 'true-false', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 17
     (q17, 'PSM-I',
      'When does a Developer become the sole owner of an item on the Sprint Backlog?',
      'The entire Scrum Team is accountable for creating a valuable, useful Increment every Sprint. The set of Product Backlog items selected for the Sprint is collectively owned by the Developers. No individual Developer can claim sole ownership over an item.',
      'Toàn bộ Scrum Team chịu trách nhiệm tạo Increment có giá trị mỗi Sprint. Các item trong Sprint Backlog thuộc sở hữu CHUNG của Developers. Không Developer nào "sở hữu riêng" một item — vì điều đó sẽ chặn giao tiếp và cộng tác.',
-     ARRAY['sprint-backlog', 'developers', 'ownership'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint-backlog', 'developers', 'ownership', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 18
     (q18, 'PSM-I',
      'Who is required to attend the Daily Scrum?',
      'Only the people doing the work described on the Sprint Backlog need to inspect and adapt at the Daily Scrum. If the Product Owner or Scrum Master are actively working on items in the Sprint Backlog, they participate as Developers.',
      'Chỉ những người đang thực hiện công việc trong Sprint Backlog cần tham gia Daily Scrum. Nếu Product Owner hoặc Scrum Master đang làm việc trên các item Sprint Backlog, họ tham gia với tư cách Developers.',
-     ARRAY['daily-scrum', 'developers'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['daily-scrum', 'developers', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 19
     (q19, 'PSM-I',
      'The timebox for a Daily Scrum is?',
      'The Daily Scrum is always a 15-minute event. Because it is a short event, the timebox is not influenced by the Sprint length.',
      'Daily Scrum LUÔN LUÔN là sự kiện 15 phút. Vì là sự kiện ngắn, timebox không bị ảnh hưởng bởi độ dài của Sprint (khác với Sprint Planning/Review/Retrospective).',
-     ARRAY['daily-scrum', 'timebox'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['daily-scrum', 'timebox', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 20
     (q20, 'PSM-I',
      'How much work must the Developers complete for each Sprint?',
      'The purpose of each Sprint is to deliver useful and valuable Increments that adhere to the Scrum Team''s current Definition of Done.',
      'Mục đích của mỗi Sprint là tạo ra Increment hữu ích và có giá trị, đáp ứng Definition of Done hiện tại của Scrum Team. Không phải "càng nhiều càng tốt" mà là "đủ để đạt DoD".',
-     ARRAY['definition-of-done', 'increment', 'sprint'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['definition-of-done', 'increment', 'sprint', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 21
     (q21, 'PSM-I',
      'The timebox for the Sprint Review is:',
      'Sprint Review is a maximum four-hour timeboxed event for one-month Sprints. For shorter Sprints, the event is usually shorter.',
      'Sprint Review có timebox tối đa 4 giờ cho Sprint một tháng. Sprint ngắn hơn thì sự kiện này thường ngắn hơn tương ứng.',
-     ARRAY['sprint-review', 'timebox'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint-review', 'timebox', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 22
     (q22, 'PSM-I',
-     'Which statement best describes Scrum?',
-     'Scrum is a lightweight framework that helps people, teams and organizations generate value through adaptive solutions for complex problems.',
-     'Scrum là một framework nhẹ giúp con người, nhóm và tổ chức tạo ra giá trị thông qua các giải pháp thích nghi cho các vấn đề phức tạp. KHÔNG phải methodology đầy đủ, KHÔNG phải cookbook best practices.',
-     ARRAY['scrum', 'framework', 'definition'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     'What is the purpose of the Sprint Goal?',
+     'The Sprint Goal is the single objective for the Sprint. It provides flexibility to the Developers regarding the exact work needed to achieve it, but also creates coherence and focus, encouraging the Scrum Team to work together rather than on separate initiatives.',
+     'Sprint Goal là mục tiêu DUY NHẤT của Sprint. Nó cho phép Developers linh hoạt về công việc cụ thể để đạt được mục tiêu, đồng thời tạo sự gắn kết và tập trung — khuyến khích cả nhóm cùng làm việc hướng tới một mục tiêu chung thay vì các sáng kiến riêng lẻ.',
+     ARRAY['sprint-goal', 'sprint-planning', 'focus', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 23 (multi-select: choose 3)
     (q23, 'PSM-I',
      'What are three incorrect, untrue, or misleading statements about Scrum? (choose the best three answers)',
      'Scrum is meant to be implemented as prescribed in the Scrum Guide — you cannot pick and choose. Scrum does NOT eliminate complexity; it provides a framework for dealing with it. Project Managers are not simply replaced by self-managing teams — Scrum optimizes decision making based on the entire team''s knowledge.',
      'Ba phát biểu sai/gây hiểu nhầm: (A) Scrum không phải methodology để chọn-bỏ tùy ý; (D) Scrum không phải process truyền thống chỉ thay PM bằng tự-tổ-chức; (E) Scrum KHÔNG loại bỏ độ phức tạp — mà cung cấp framework để xử lý nó. Các phát biểu B, C, F là đúng.',
-     ARRAY['scrum', 'framework', 'misconceptions', 'multi-select'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['scrum', 'framework', 'misconceptions', 'multi-select', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 24
     (q24, 'PSM-I',
      'When might a Sprint be cancelled?',
      'A Sprint could be cancelled if the Sprint Goal becomes obsolete. Only the Product Owner has the authority to cancel the Sprint.',
      'Sprint chỉ bị hủy khi Sprint Goal trở nên lỗi thời. Chỉ có Product Owner mới có quyền hủy Sprint — không phải vì "công việc khó", "có cơ hội mới", hay "không kịp hoàn thành".',
-     ARRAY['sprint', 'sprint-goal', 'product-owner', 'cancellation'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint', 'sprint-goal', 'product-owner', 'cancellation', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 25
     (q25, 'PSM-I',
      'Who should know the most about the progress toward a business objective or a release, and be able to explain the alternatives most clearly?',
      'The Product Owner is accountable for maximizing the value of the product resulting from the work of the Scrum Team. Their accountabilities include developing and communicating the Product Goal, creating and communicating Product Backlog items, ordering the Product Backlog, and ensuring it is transparent, visible and understood.',
      'Product Owner là người nắm rõ nhất tiến độ hướng tới mục tiêu kinh doanh và bản phát hành. PO có trách nhiệm: phát triển và truyền đạt Product Goal, tạo và truyền đạt các Product Backlog item, sắp xếp Product Backlog và đảm bảo nó minh bạch.',
-     ARRAY['product-owner', 'product-backlog', 'product-goal'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['product-owner', 'product-backlog', 'product-goal', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 26 (true/false)
     (q26, 'PSM-I',
      'True or False: When multiple Scrum Teams work together on the same product, each team should maintain a separate Product Backlog.',
      'Products have one Product Backlog, regardless of how many Scrum Teams are used. Any other setup makes it difficult for the Developers to determine what they should work on.',
      'Mỗi sản phẩm chỉ có MỘT Product Backlog, bất kể có bao nhiêu Scrum Team cùng làm. Cách bố trí khác sẽ khiến Developers khó xác định nên làm gì.',
-     ARRAY['product-backlog', 'scaling', 'true-false'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['product-backlog', 'scaling', 'true-false', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 27
     (q27, 'PSM-I',
      'During a Sprint, a Developer determines that the Scrum Team will not be able to complete the items in their forecast. Who should be present to review and adjust the Product Backlog items selected?',
      'During the Sprint, scope may be clarified and re-negotiated between the Product Owner and the Developers as more is learned. It is important to be transparent when challenges arise since the entire Scrum Team is accountable for creating a valuable, useful Increment.',
      'Trong Sprint, phạm vi có thể được làm rõ và đàm phán lại giữa Product Owner và Developers khi học được thêm. Phải minh bạch khi gặp khó khăn — vì toàn Scrum Team chịu trách nhiệm tạo Increment có giá trị.',
-     ARRAY['sprint', 'product-owner', 'developers', 'scope'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['sprint', 'product-owner', 'developers', 'scope', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 28
     (q28, 'PSM-I',
      'Who has the final say on the order of the Product Backlog?',
      'The Product Owner is the sole person responsible for ordering the Product Backlog. Others may influence by suggesting trade-offs, but the final decision belongs to the Product Owner.',
      'Product Owner là người DUY NHẤT chịu trách nhiệm sắp xếp Product Backlog. Người khác có thể góp ý về trade-off, nhưng quyết định cuối cùng thuộc về Product Owner — không phải CEO, Scrum Master, Developers hay stakeholders.',
-     ARRAY['product-owner', 'product-backlog', 'ordering'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['product-owner', 'product-backlog', 'ordering', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 29 (true/false)
     (q29, 'PSM-I',
      'True or False: It is mandatory that the product Increment be released to production at the end of each Sprint.',
      'The product Increment should be usable at the end of every Sprint, but it does not have to be released. Release decisions belong to the Product Owner based on business needs.',
      'Increment phải SỬ DỤNG ĐƯỢC vào cuối mỗi Sprint, nhưng KHÔNG bắt buộc phải release lên production. Quyết định release thuộc về Product Owner dựa trên nhu cầu kinh doanh.',
-     ARRAY['increment', 'release', 'true-false'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
+     ARRAY['increment', 'release', 'true-false', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted'),
 
     -- 30
     (q30, 'PSM-I',
      'The Product Backlog is ordered by:',
      'The Product Owner is accountable for effective Product Backlog management. The Product Backlog is an emergent, ordered list of what is needed to improve the product. It is the single source of work undertaken by the Scrum Team. The Product Owner orders it however they deem most appropriate.',
      'Product Owner chịu trách nhiệm quản lý hiệu quả Product Backlog. Đây là danh sách nổi-lên (emergent) và có thứ tự về những gì cần để cải thiện sản phẩm. Product Owner sắp xếp theo cách họ thấy phù hợp nhất — không bị ràng buộc theo rủi ro, kích thước hay giá trị đơn thuần.',
-     ARRAY['product-backlog', 'product-owner', 'ordering'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted');
+     ARRAY['product-backlog', 'product-owner', 'ordering', 'scrum-open-pool-2'], '{}'::uuid[], 'Scrum Open Assessment', 'trusted');
 
   -- ────────────────────────────────────────────────────────────
   -- Options
@@ -389,12 +397,12 @@ BEGIN
     (gen_random_uuid(), q21, 'As long as needed.', false, 3),
     (gen_random_uuid(), q21, '1 day.', false, 4);
 
-  -- Q22: What is Scrum
+  -- Q22: Purpose of the Sprint Goal
   INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES
-    (gen_random_uuid(), q22, 'A complete methodology that defines how to develop software.', false, 0),
-    (gen_random_uuid(), q22, 'A defined and predictive process that conforms to the principles of Scientific Management.', false, 1),
-    (gen_random_uuid(), q22, 'A cookbook that defines best practices for software development.', false, 2),
-    (gen_random_uuid(), q22, 'A framework for creating complex products in complex environments.', true, 3);
+    (gen_random_uuid(), q22, 'To lock in the exact set of features the Developers must deliver in the Sprint.', false, 0),
+    (gen_random_uuid(), q22, 'To provide a single objective that creates coherence and focus for the Scrum Team.', true, 1),
+    (gen_random_uuid(), q22, 'To give management a fixed commitment on what will be done.', false, 2),
+    (gen_random_uuid(), q22, 'To replace the Product Backlog for the duration of the Sprint.', false, 3);
 
   -- Q23: Three incorrect statements about Scrum (multi-select, 3)
   INSERT INTO public.question_options (id, question_id, text, correct, sort_order) VALUES

--- a/supabase/seed_scrum_open_v2.sql
+++ b/supabase/seed_scrum_open_v2.sql
@@ -13,23 +13,38 @@ DELETE FROM public.questions
     AND 'scrum-open-pool-2' = ANY(tags);
 
 DO $$ DECLARE
-  q1  uuid; q2  uuid; q3  uuid; q4  uuid; q5  uuid;
-  q6  uuid; q7  uuid; q8  uuid; q9  uuid; q10 uuid;
-  q11 uuid; q12 uuid; q13 uuid; q14 uuid; q15 uuid;
-  q16 uuid; q17 uuid; q18 uuid; q19 uuid; q20 uuid;
-  q21 uuid; q22 uuid; q23 uuid; q24 uuid; q25 uuid;
-  q26 uuid; q27 uuid; q28 uuid; q29 uuid; q30 uuid;
+  -- Static UUIDs: stable across re-runs so public.progress records are preserved.
+  q1   uuid := '895574b9-b254-4b5d-b60e-a380fa656d1f';
+  q2   uuid := 'b1c4c523-8e38-4b1c-83a3-8b01127aa774';
+  q3   uuid := '54508494-2d07-47a4-987a-3c66c7712c9d';
+  q4   uuid := '1f1bd4fb-9b0a-4c35-bfe9-9f309bc42ff5';
+  q5   uuid := '91ae970d-04d8-485a-a414-e88c5ee9178e';
+  q6   uuid := '36ddbf8c-b96c-4811-8a6a-87bf6d63a298';
+  q7   uuid := 'ee451a29-3984-4544-8b74-107b93562187';
+  q8   uuid := '58d397ad-b7ca-4620-9dcf-2d6175e19f0f';
+  q9   uuid := 'e808d062-9684-4ad9-8d24-d88c31db62ba';
+  q10  uuid := '6e1a0417-d887-452f-8d09-530b93635ed7';
+  q11  uuid := 'dbfeabab-59c0-4349-99ec-02436039a2a0';
+  q12  uuid := 'd000ab85-3d57-423c-abea-1f3fe183839e';
+  q13  uuid := '0e220843-e8f9-4d8e-ab8c-43fe1e2e5f0a';
+  q14  uuid := 'e80430a2-ae0d-4fc0-a3fc-70755da67def';
+  q15  uuid := 'bfce5387-7d99-41af-87fd-a86b8b3172b6';
+  q16  uuid := 'e1229da9-93bd-499f-b728-2ea49fb2933b';
+  q17  uuid := 'c29213e6-9e5a-48fb-afe6-193060555ec6';
+  q18  uuid := 'c5c2c436-4e4d-42a2-acf2-0b6acaf88974';
+  q19  uuid := '23d82cfa-6bb5-4e89-a1be-a3d046f216c9';
+  q20  uuid := '91b6e187-3632-4192-99db-ac6b988b4dd6';
+  q21  uuid := '5049594c-4a13-40fb-b3f7-ae59de6a70fe';
+  q22  uuid := 'df03e597-e47a-4253-8342-149e038b15e2';
+  q23  uuid := 'd29f8b20-9bda-4e4e-a029-cb4e7c0f2576';
+  q24  uuid := '9197a9b9-7edd-4ac2-9744-c1efb6822634';
+  q25  uuid := 'c67666b6-c7ed-41f7-b988-d8723bfa23c4';
+  q26  uuid := 'b623f0a5-cc1d-46a8-a469-a8695e60f9d1';
+  q27  uuid := '57f50ed9-cd01-4d39-8c9e-cf4ec71a25c2';
+  q28  uuid := '2d6bb48b-0bb8-46b2-8951-8d30eee394a8';
+  q29  uuid := '5dbea826-6f3f-4cbd-a4f9-9cc44e7d8e48';
+  q30  uuid := 'd7de55f6-ca0a-41de-af0d-9e36e26a12fd';
 BEGIN
-  q1  := gen_random_uuid(); q2  := gen_random_uuid(); q3  := gen_random_uuid();
-  q4  := gen_random_uuid(); q5  := gen_random_uuid(); q6  := gen_random_uuid();
-  q7  := gen_random_uuid(); q8  := gen_random_uuid(); q9  := gen_random_uuid();
-  q10 := gen_random_uuid(); q11 := gen_random_uuid(); q12 := gen_random_uuid();
-  q13 := gen_random_uuid(); q14 := gen_random_uuid(); q15 := gen_random_uuid();
-  q16 := gen_random_uuid(); q17 := gen_random_uuid(); q18 := gen_random_uuid();
-  q19 := gen_random_uuid(); q20 := gen_random_uuid(); q21 := gen_random_uuid();
-  q22 := gen_random_uuid(); q23 := gen_random_uuid(); q24 := gen_random_uuid();
-  q25 := gen_random_uuid(); q26 := gen_random_uuid(); q27 := gen_random_uuid();
-  q28 := gen_random_uuid(); q29 := gen_random_uuid(); q30 := gen_random_uuid();
 
   -- ────────────────────────────────────────────────────────────
   -- Questions


### PR DESCRIPTION
Pool 1 (seed_scrum_open.sql) and Pool 2 (seed_scrum_open_v2.sql) were both crawled from scrum.org Open Assessment. Comparing stems found 1 exact duplicate ("Which statement best describes Scrum?") and ~7 near-topic overlaps with different phrasing (kept since different wording reinforces learning).

Changes:
- Pool 2 Q22 replaced (Sprint Goal purpose) to remove the exact dup.
- Each question tagged 'scrum-open-pool-1' or 'scrum-open-pool-2'.
- Each seed starts with DELETE WHERE tag = pool-N → safe to re-run; re-running one pool does not affect the other.
- Migration 006 adds UNIQUE(stem) on questions: future crawls with colliding stems fail loudly instead of silently duplicating.