### PR TITLE
fix: scope progress by user_id so it follows the Google account, not the device

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,5 +1,6 @@
 import Dexie, { type Table } from 'dexie';
 import type { Term, TermSense, Question, QuestionOption, LocalProgress, LookedUpTerm } from './types';
+import { LEGACY_PROGRESS_USER_ID } from './types';
 
 export class KfrDB extends Dexie {
   terms!: Table<Term>;
@@ -19,6 +20,24 @@ export class KfrDB extends Dexie {
       progress: '[itemType+itemId], itemType, nextReview',
       lookedUpTerms: 'termId, lastLookedAt',
     });
+
+    // v2: scope progress per-user so a device shared by multiple Google
+    // accounts (or the same account being added later) doesn't blend rows.
+    // Old rows are tagged with a legacy marker so the next logged-in user
+    // can claim them (upload to Supabase under their id) instead of losing
+    // any device-only progress that never synced.
+    this.version(2)
+      .stores({
+        progress: '[userId+itemType+itemId], userId, itemType, nextReview',
+      })
+      .upgrade(async (tx) => {
+        const old = await tx.table('progress').toArray();
+        await tx.table('progress').clear();
+        if (!old.length) return;
+        await tx
+          .table('progress')
+          .bulkAdd(old.map((p) => ({ ...p, userId: LEGACY_PROGRESS_USER_ID })));
+      });
   }
 }
 

--- a/src/lib/srs.ts
+++ b/src/lib/srs.ts
@@ -1,4 +1,4 @@
-import type { LocalProgress } from './types';
+import type { ProgressInput } from './types';
 
 const DAY = 24 * 60 * 60 * 1000;
 
@@ -9,19 +9,19 @@ export const XPS_INCENTIVE = 2;
 export const BADGES = ['🥉', '🥈', '🥇', '🏆', '💎'];
 export const MAX_LEVEL = SRS_INTERVALS.length - 1;
 
-export function canPractice(progress: LocalProgress | undefined): boolean {
+export function canPractice(progress: ProgressInput | undefined): boolean {
   if (!progress) return true;
   if (!progress.nextReview) return true;
   return Date.now() >= new Date(progress.nextReview).getTime();
 }
 
 export function improveProgress(
-  current: LocalProgress | undefined,
+  current: ProgressInput | undefined,
   itemType: 'term' | 'question',
   itemId: string,
   wrong: boolean
-): LocalProgress {
-  const base = current ?? { itemType, itemId, level: -1, xp: 0, nextReview: null };
+): ProgressInput {
+  const base: ProgressInput = current ?? { itemType, itemId, level: -1, xp: 0, nextReview: null };
 
   if (wrong) {
     return {
@@ -49,11 +49,11 @@ export function getBadge(level: number): string {
   return BADGES.slice(0, level + 1).join('');
 }
 
-export function getTotalXP(progresses: LocalProgress[]): number {
+export function getTotalXP(progresses: ProgressInput[]): number {
   return progresses.reduce((sum, p) => sum + p.xp, 0);
 }
 
-export function getLevelCounts(progresses: LocalProgress[]): number[] {
+export function getLevelCounts(progresses: ProgressInput[]): number[] {
   return BADGES.map((_, i) => progresses.filter((p) => p.level >= i).length);
 }
 

--- a/src/lib/stores/mastery.ts
+++ b/src/lib/stores/mastery.ts
@@ -1,7 +1,9 @@
-import { writable, derived } from 'svelte/store';
-import type { LocalProgress } from '$lib/types';
+import { writable, derived, get } from 'svelte/store';
+import type { LocalProgress, ProgressInput } from '$lib/types';
 import { getTotalXP, getLevelCounts } from '$lib/srs';
 import { db } from '$lib/db';
+import { supabase } from '$lib/supabase';
+import { authUser } from '$lib/stores/auth';
 
 export const progressMap = writable<Map<string, LocalProgress>>(new Map());
 
@@ -17,19 +19,51 @@ export function getProgress(
   return map.get(progressKey(itemType, itemId));
 }
 
-export async function loadMastery(): Promise<void> {
-  const all = await db.progress.toArray();
+export async function loadMastery(userId: string): Promise<void> {
+  const all = await db.progress.where('userId').equals(userId).toArray();
   const map = new Map(all.map((p) => [progressKey(p.itemType, p.itemId), p]));
   progressMap.set(map);
 }
 
-export async function saveProgress(progress: LocalProgress): Promise<void> {
-  await db.progress.put(progress);
+export function clearMastery(): void {
+  progressMap.set(new Map());
+}
+
+export async function saveProgress(progress: ProgressInput): Promise<void> {
+  const user = get(authUser);
+  if (!user) return;
+
+  const now = new Date().toISOString();
+  const row: LocalProgress = { ...progress, userId: user.id };
+
+  await db.progress.put(row);
   progressMap.update((m) => {
     const next = new Map(m);
-    next.set(progressKey(progress.itemType, progress.itemId), progress);
+    next.set(progressKey(row.itemType, row.itemId), row);
     return next;
   });
+
+  const { error } = await supabase.from('progress').upsert(
+    {
+      user_id: user.id,
+      item_type: row.itemType,
+      item_id: row.itemId,
+      level: row.level,
+      xp: row.xp,
+      next_review: row.nextReview,
+      updated_at: now,
+    },
+    { onConflict: 'user_id,item_type,item_id' }
+  );
+
+  if (error) {
+    // Local copy is kept without `syncedAt` so the next `syncProgressUp`
+    // catches it up.
+    console.warn('Failed to sync progress to Supabase:', error);
+    return;
+  }
+
+  await db.progress.put({ ...row, syncedAt: now });
 }
 
 export const stats = derived(progressMap, ($map) => {

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -1,19 +1,30 @@
 import { supabase } from './supabase';
 import { db } from './db';
 import type { LocalProgress } from './types';
+import { LEGACY_PROGRESS_USER_ID } from './types';
 
+/**
+ * Upload any local progress rows for `userId` that haven't been synced yet
+ * (no `syncedAt`). Called after sign-in so offline edits made on this device
+ * eventually reach the server.
+ */
 export async function syncProgressUp(userId: string): Promise<void> {
-  const local = await db.progress.toArray();
-  if (!local.length) return;
+  const unsynced = await db.progress
+    .where('userId')
+    .equals(userId)
+    .filter((p) => !p.syncedAt)
+    .toArray();
+  if (!unsynced.length) return;
 
-  const rows = local.map((p) => ({
+  const now = new Date().toISOString();
+  const rows = unsynced.map((p) => ({
     user_id: userId,
     item_type: p.itemType,
     item_id: p.itemId,
     level: p.level,
     xp: p.xp,
     next_review: p.nextReview,
-    updated_at: new Date().toISOString(),
+    updated_at: now,
   }));
 
   const { error } = await supabase
@@ -22,9 +33,40 @@ export async function syncProgressUp(userId: string): Promise<void> {
 
   if (error) throw error;
 
-  await db.progress.bulkPut(
-    local.map((p) => ({ ...p, syncedAt: new Date().toISOString() }))
-  );
+  await db.progress.bulkPut(unsynced.map((p) => ({ ...p, syncedAt: now })));
+}
+
+/**
+ * Claim any rows left from before per-user scoping existed (Dexie v1) by
+ * uploading them to Supabase under the current user, then dropping the
+ * legacy marker rows. This preserves device-only progress for the user who
+ * first logs in after the fix lands.
+ */
+export async function claimLegacyProgress(userId: string): Promise<void> {
+  const legacy = await db.progress
+    .where('userId')
+    .equals(LEGACY_PROGRESS_USER_ID)
+    .toArray();
+  if (!legacy.length) return;
+
+  const now = new Date().toISOString();
+  const rows = legacy.map((p) => ({
+    user_id: userId,
+    item_type: p.itemType,
+    item_id: p.itemId,
+    level: p.level,
+    xp: p.xp,
+    next_review: p.nextReview,
+    updated_at: now,
+  }));
+
+  const { error } = await supabase
+    .from('progress')
+    .upsert(rows, { onConflict: 'user_id,item_type,item_id' });
+
+  if (error) throw error;
+
+  await db.progress.where('userId').equals(LEGACY_PROGRESS_USER_ID).delete();
 }
 
 export async function syncProgressDown(userId: string): Promise<void> {
@@ -36,21 +78,23 @@ export async function syncProgressDown(userId: string): Promise<void> {
   if (error) throw error;
   if (!data?.length) return;
 
-  const local = await db.progress.toArray();
+  const local = await db.progress.where('userId').equals(userId).toArray();
   const localMap = new Map(local.map((p) => [`${p.itemType}:${p.itemId}`, p]));
 
+  const now = new Date().toISOString();
   const merged: LocalProgress[] = data.map((row) => {
     const key = `${row.item_type}:${row.item_id}`;
     const localP = localMap.get(key);
 
     if (!localP) {
       return {
+        userId,
         itemType: row.item_type,
         itemId: row.item_id,
         level: row.level,
         xp: row.xp,
         nextReview: row.next_review,
-        syncedAt: new Date().toISOString(),
+        syncedAt: now,
       };
     }
 
@@ -65,12 +109,13 @@ export async function syncProgressDown(userId: string): Promise<void> {
             : row.next_review;
 
     return {
+      userId,
       itemType: row.item_type,
       itemId: row.item_id,
       level: Math.max(localP.level, row.level),
       xp: Math.max(localP.xp, row.xp),
       nextReview,
-      syncedAt: new Date().toISOString(),
+      syncedAt: now,
     };
   });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,6 +44,7 @@ export interface QuestionOption {
 }
 
 export interface LocalProgress {
+  userId: string;
   itemType: 'term' | 'question';
   itemId: string;
   level: number;
@@ -51,6 +52,14 @@ export interface LocalProgress {
   nextReview: string | null;
   syncedAt?: string;
 }
+
+/** Progress payload shape without identity/sync metadata. SRS produces this;
+ *  `saveProgress` tags on the userId before persisting. */
+export type ProgressInput = Omit<LocalProgress, 'userId' | 'syncedAt'>;
+
+/** Marker used by Dexie v2 upgrade to flag pre-userId rows that need to be
+ *  claimed by the next user who logs in. */
+export const LEGACY_PROGRESS_USER_ID = '__legacy__';
 
 export interface LookedUpTerm {
   termId: string;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,9 +5,9 @@
   import '../app.css';
   import { supabase } from '$lib/supabase';
   import { authUser, authLoading } from '$lib/stores/auth';
-  import { loadMastery, stats } from '$lib/stores/mastery';
+  import { loadMastery, clearMastery, stats } from '$lib/stores/mastery';
   import { syncContent } from '$lib/content';
-  import { syncProgressDown } from '$lib/sync';
+  import { syncProgressDown, syncProgressUp, claimLegacyProgress } from '$lib/sync';
   import { BADGES } from '$lib/srs';
 
   async function initSession() {
@@ -38,12 +38,21 @@
         await onUserReady(sess.user.id);
       } else {
         authUser.set(null);
+        clearMastery();
       }
     });
   }
 
   async function onUserReady(userId: string) {
-    await Promise.all([syncContent(), syncProgressDown(userId), loadMastery()]);
+    // Order matters:
+    //  1. claim any pre-v2 rows under this user so they survive
+    //  2. push anything saved locally but not yet uploaded
+    //  3. pull the merged server state down
+    //  4. populate the in-memory map (scoped by userId)
+    await claimLegacyProgress(userId);
+    await syncProgressUp(userId);
+    await Promise.all([syncContent(), syncProgressDown(userId)]);
+    await loadMastery(userId);
   }
 
   async function signIn() {
@@ -56,6 +65,7 @@
   async function signOut() {
     await supabase.auth.signOut();
     authUser.set(null);
+    clearMastery();
   }
 
   onMount(initSession);


### PR DESCRIPTION
saveProgress() only wrote to local IndexedDB; syncProgressUp() existed but was
never called, so per-device XP/SRS state never reached Supabase — the same
Google account on a different device saw a different empty profile.

- Add userId to LocalProgress; Dexie v2 keys by [userId+itemType+itemId].
- saveProgress() upserts to Supabase on the spot and tags syncedAt when ok.
- syncProgressUp() now retries unsynced rows (offline edits) on next sign-in.
- claimLegacyProgress() uploads pre-v2 rows under the next user that logs in
  so existing device-only progress isn't lost during the migration.
- loadMastery(userId) and syncProgressDown(userId) filter by current user;
  clearMastery() runs on sign-out so a different account can't see leftovers.

https://claude.ai/code/session_01TKW86GQrkJm2wyXK8QJLSr