### PR TITLE
Fix Dexie primary-key migration crash and PWA manifest base-path errors

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -7,7 +7,7 @@ export class KfrDB extends Dexie {
   termSenses!: Table<TermSense>;
   questions!: Table<Question>;
   questionOptions!: Table<QuestionOption>;
-  progress!: Table<LocalProgress>;
+  progressV2!: Table<LocalProgress>;
   lookedUpTerms!: Table<LookedUpTerm>;
 
   constructor() {
@@ -26,18 +26,29 @@ export class KfrDB extends Dexie {
     // Old rows are tagged with a legacy marker so the next logged-in user
     // can claim them (upload to Supabase under their id) instead of losing
     // any device-only progress that never synced.
+    //
+    // NOTE: Dexie does not support changing the primary key of an existing
+    // object store, so we cannot rename the key path of `progress` in-place.
+    // Instead, we create a new `progressV2` table with the correct composite
+    // key and migrate rows there, then drop the old `progress` table in v3.
     this.version(2)
       .stores({
-        progress: '[userId+itemType+itemId], userId, itemType, nextReview',
+        progress: '[itemType+itemId], itemType, nextReview', // keep old schema unchanged
+        progressV2: '[userId+itemType+itemId], userId, itemType, nextReview',
       })
       .upgrade(async (tx) => {
         const old = await tx.table('progress').toArray();
-        await tx.table('progress').clear();
+        await tx.table('progressV2').clear();
         if (!old.length) return;
         await tx
-          .table('progress')
+          .table('progressV2')
           .bulkAdd(old.map((p) => ({ ...p, userId: LEGACY_PROGRESS_USER_ID })));
       });
+
+    // v3: drop the now-redundant old progress table.
+    this.version(3).stores({
+      progress: null,
+    });
   }
 }
 

--- a/src/lib/stores/mastery.ts
+++ b/src/lib/stores/mastery.ts
@@ -20,7 +20,7 @@ export function getProgress(
 }
 
 export async function loadMastery(userId: string): Promise<void> {
-  const all = await db.progress.where('userId').equals(userId).toArray();
+  const all = await db.progressV2.where('userId').equals(userId).toArray();
   const map = new Map(all.map((p) => [progressKey(p.itemType, p.itemId), p]));
   progressMap.set(map);
 }
@@ -36,7 +36,7 @@ export async function saveProgress(progress: ProgressInput): Promise<void> {
   const now = new Date().toISOString();
   const row: LocalProgress = { ...progress, userId: user.id };
 
-  await db.progress.put(row);
+  await db.progressV2.put(row);
   progressMap.update((m) => {
     const next = new Map(m);
     next.set(progressKey(row.itemType, row.itemId), row);
@@ -63,7 +63,7 @@ export async function saveProgress(progress: ProgressInput): Promise<void> {
     return;
   }
 
-  await db.progress.put({ ...row, syncedAt: now });
+  await db.progressV2.put({ ...row, syncedAt: now });
 }
 
 export const stats = derived(progressMap, ($map) => {

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -9,7 +9,7 @@ import { LEGACY_PROGRESS_USER_ID } from './types';
  * eventually reach the server.
  */
 export async function syncProgressUp(userId: string): Promise<void> {
-  const unsynced = await db.progress
+  const unsynced = await db.progressV2
     .where('userId')
     .equals(userId)
     .filter((p) => !p.syncedAt)
@@ -33,7 +33,7 @@ export async function syncProgressUp(userId: string): Promise<void> {
 
   if (error) throw error;
 
-  await db.progress.bulkPut(unsynced.map((p) => ({ ...p, syncedAt: now })));
+  await db.progressV2.bulkPut(unsynced.map((p) => ({ ...p, syncedAt: now })));
 }
 
 /**
@@ -43,7 +43,7 @@ export async function syncProgressUp(userId: string): Promise<void> {
  * first logs in after the fix lands.
  */
 export async function claimLegacyProgress(userId: string): Promise<void> {
-  const legacy = await db.progress
+  const legacy = await db.progressV2
     .where('userId')
     .equals(LEGACY_PROGRESS_USER_ID)
     .toArray();
@@ -66,7 +66,7 @@ export async function claimLegacyProgress(userId: string): Promise<void> {
 
   if (error) throw error;
 
-  await db.progress.where('userId').equals(LEGACY_PROGRESS_USER_ID).delete();
+  await db.progressV2.where('userId').equals(LEGACY_PROGRESS_USER_ID).delete();
 }
 
 export async function syncProgressDown(userId: string): Promise<void> {
@@ -78,7 +78,7 @@ export async function syncProgressDown(userId: string): Promise<void> {
   if (error) throw error;
   if (!data?.length) return;
 
-  const local = await db.progress.where('userId').equals(userId).toArray();
+  const local = await db.progressV2.where('userId').equals(userId).toArray();
   const localMap = new Map(local.map((p) => [`${p.itemType}:${p.itemId}`, p]));
 
   const now = new Date().toISOString();
@@ -119,5 +119,5 @@ export async function syncProgressDown(userId: string): Promise<void> {
     };
   });
 
-  await db.progress.bulkPut(merged);
+  await db.progressV2.bulkPut(merged);
 }

--- a/static/manifest.webmanifest
+++ b/static/manifest.webmanifest
@@ -2,15 +2,16 @@
   "name": "KfR — Scrum Learning",
   "short_name": "KfR",
   "description": "Học tiếng Anh chuyên ngành Scrum · Luyện thi PSM I & PSPO I",
-  "start_url": "/",
+  "start_url": "./",
+  "scope": "./",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#1976d2",
   "lang": "vi",
   "icons": [
-    { "src": "/icons/icon-72.png",  "sizes": "72x72",   "type": "image/png" },
-    { "src": "/icons/icon-128.png", "sizes": "128x128", "type": "image/png" },
-    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
-    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }
+    { "src": "icons/icon-72.png",  "sizes": "72x72",   "type": "image/png" },
+    { "src": "icons/icon-128.png", "sizes": "128x128", "type": "image/png" },
+    { "src": "icons/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
+    { "src": "icons/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,12 +15,13 @@ export default defineConfig({
         theme_color: '#1976d2',
         background_color: '#ffffff',
         display: 'standalone',
-        start_url: '/',
+        start_url: './',
+        scope: './',
         icons: [
-          { src: '/icons/icon-72.png', sizes: '72x72', type: 'image/png' },
-          { src: '/icons/icon-128.png', sizes: '128x128', type: 'image/png' },
-          { src: '/icons/icon-192.png', sizes: '192x192', type: 'image/png' },
-          { src: '/icons/icon-512.png', sizes: '512x512', type: 'image/png' },
+          { src: 'icons/icon-72.png', sizes: '72x72', type: 'image/png' },
+          { src: 'icons/icon-128.png', sizes: '128x128', type: 'image/png' },
+          { src: 'icons/icon-192.png', sizes: '192x192', type: 'image/png' },
+          { src: 'icons/icon-512.png', sizes: '512x512', type: 'image/png' },
         ],
       },
       workbox: {


### PR DESCRIPTION
Three bugs reported in production (tuongna.github.io/kfr):

1. DatabaseClosedError: UpgradeError – Not yet support for changing primary key
   Dexie cannot change the primary key of an existing object store in-place.
   The v2 migration tried to alter `progress` from `[itemType+itemId]` to
   `[userId+itemType+itemId]`, which throws before the upgrade handler even
   runs, leaving all users stuck on v1 with a closed database.

   Fix: two-step migration
   • v2 – keep old `progress` schema unchanged, create new `progressV2`
     table with the correct composite primary key, copy & tag legacy rows
   • v3 – drop the now-redundant old `progress` table
   • Rename all `db.progress` → `db.progressV2` in sync.ts and mastery.ts

2. Manifest: property 'scope' ignored / start_url out of scope
   The app is deployed under /kfr/ but manifest.webmanifest declared
   `start_url: "/"` (domain root). The browser ignores the scope because the
   start URL falls outside it.

3. GET /icons/icon-192.png 404
   Icon paths used absolute URLs (`/icons/…`) which resolve to the domain
   root instead of `/kfr/icons/…`.

   Fix for 2 & 3: switch to relative paths in both static/manifest.webmanifest
   and vite.config.ts (`start_url: "./"`, `scope: "./"`, icon srcs without
   leading `/`). Relative URLs are resolved against the manifest location so
   they work correctly at any deploy base path.

https://claude.ai/code/session_01MNuBrXnXob9ZzSaJpqqrTU