### PR TITLE
fix: audit JSON parse, mobile cluster selection, state leak across terms

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -189,7 +189,7 @@ export async function auditTermSenses(
 
     const content: string = data.data?.choices?.[0]?.message?.content ?? '';
     try {
-      const parsed = JSON.parse(content.trim()) as Partial<AuditResult>;
+      const parsed = JSON.parse(extractJson(content)) as Partial<AuditResult>;
       const actualModel = data.model ?? model;
       onAttempt?.({ model: actualModel, status: 'succeeded' });
       return {
@@ -272,7 +272,7 @@ export async function translateTerm(
 
     const content: string = data.data?.choices?.[0]?.message?.content ?? '';
     try {
-      const parsed = JSON.parse(content.trim()) as Partial<TranslateResult>;
+      const parsed = JSON.parse(extractJson(content)) as Partial<TranslateResult>;
       const actualModel = data.model ?? model;
       onAttempt?.({ model: actualModel, status: 'succeeded' });
       return {
@@ -299,4 +299,19 @@ export async function translateTerm(
 function stripModelPrefix(errMsg: string, model: string): string {
   const prefix = `${model}: `;
   return errMsg.startsWith(prefix) ? errMsg.slice(prefix.length) : errMsg;
+}
+
+/**
+ * Extracts a JSON object from a model response. Handles cases where models
+ * (notably Claude Haiku) wrap the JSON in markdown code fences despite being
+ * told not to, or prepend/append explanatory prose.
+ */
+function extractJson(content: string): string {
+  const trimmed = content.trim();
+  const fenceMatch = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```\s*$/i);
+  if (fenceMatch) return fenceMatch[1].trim();
+  const start = trimmed.indexOf('{');
+  const end = trimmed.lastIndexOf('}');
+  if (start >= 0 && end > start) return trimmed.slice(start, end + 1);
+  return trimmed;
 }

--- a/src/lib/components/NgramPopup.svelte
+++ b/src/lib/components/NgramPopup.svelte
@@ -245,6 +245,17 @@
 
   function onPointerMove(e: PointerEvent) {
     if (dragOrigin === null) return;
+    // Auto-scroll when the user drags near the slider edges so off-screen
+    // notches on small screens become reachable while pointer is captured.
+    if (sliderEl) {
+      const rect = sliderEl.getBoundingClientRect();
+      const edge = 40;
+      if (e.clientX < rect.left + edge) {
+        sliderEl.scrollLeft -= Math.max(6, (rect.left + edge - e.clientX) / 3);
+      } else if (e.clientX > rect.right - edge) {
+        sliderEl.scrollLeft += Math.max(6, (e.clientX - (rect.right - edge)) / 3);
+      }
+    }
     const idx = notchIndexFromX(e.clientX);
     if (idx === null) return;
     leftIdx = Math.min(dragOrigin, idx);
@@ -272,7 +283,12 @@
     return first === -1 ? null : { first, last };
   }
 
-  function onSliderKey(e: KeyboardEvent) {
+  function scrollNotchIntoView(idx: number) {
+    const notch = sliderEl?.querySelector<HTMLElement>(`.ngram-notch[data-index="${idx}"]`);
+    notch?.scrollIntoView({ inline: 'nearest', block: 'nearest' });
+  }
+
+  async function onSliderKey(e: KeyboardEvent) {
     if (e.key === 'Enter') {
       e.preventDefault();
       translateAndSelect(selectedPhrase);
@@ -301,7 +317,11 @@
       e.preventDefault();
       if (moveEnd === 'right') rightIdx = bounds.last;
       else leftIdx = rightIdx;
+    } else {
+      return;
     }
+    await tick();
+    scrollNotchIntoView(moveEnd === 'right' ? rightIdx : leftIdx);
   }
 </script>
 

--- a/src/lib/components/TermPopup.svelte
+++ b/src/lib/components/TermPopup.svelte
@@ -94,8 +94,8 @@
   async function loadTerm(id: string) {
     loading = true;
     editMode = false;
-    auditResult = null;
-    auditError = '';
+    resetAuditState();
+    resetRetranslateState();
     [term, senses] = await Promise.all([
       db.terms.get(id).then((t) => t ?? null),
       db.termSenses.where('termId').equals(id).sortBy('sortOrder'),
@@ -117,9 +117,28 @@
     term = null;
     senses = [];
     editMode = false;
+    resetAuditState();
+    resetRetranslateState();
+    dispatch('close');
+  }
+
+  function resetAuditState() {
+    stopAuditTimer();
+    auditing = false;
     auditResult = null;
     auditError = '';
-    dispatch('close');
+    auditAttempts = [];
+    auditElapsed = 0;
+    auditFinalElapsed = 0;
+  }
+
+  function resetRetranslateState() {
+    stopRetranslateTimer();
+    retranslating = false;
+    retranslateError = '';
+    retranslateAttempts = [];
+    retranslateElapsed = 0;
+    retranslateFinalElapsed = 0;
   }
 
   async function markKnown() {
@@ -287,16 +306,18 @@
   // Audit functions
   async function auditTerm() {
     if (!term) return;
+    const startedTermId = term.id;
     auditing = true;
     auditError = '';
     auditResult = null;
     auditAttempts = [];
     startAuditTimer();
     try {
-      auditResult = await auditTermSenses(
+      const result = await auditTermSenses(
         term.text,
         senses.map((s) => ({ register: s.register, en: s.en, vi: s.vi })),
         (a) => {
+          if (term?.id !== startedTermId) return;
           const last = auditAttempts[auditAttempts.length - 1];
           if (last && last.model === a.model && last.status === 'trying') {
             auditAttempts = [...auditAttempts.slice(0, -1), a];
@@ -305,12 +326,17 @@
           }
         }
       );
+      if (term?.id === startedTermId) auditResult = result;
     } catch (e: unknown) {
-      auditError = e instanceof Error ? e.message : String(e);
+      if (term?.id === startedTermId) {
+        auditError = e instanceof Error ? e.message : String(e);
+      }
     } finally {
-      auditFinalElapsed = auditElapsed;
-      auditing = false;
-      stopAuditTimer();
+      if (term?.id === startedTermId) {
+        auditFinalElapsed = auditElapsed;
+        auditing = false;
+        stopAuditTimer();
+      }
     }
   }
 
@@ -320,12 +346,14 @@
    */
   async function retranslateTerm() {
     if (!term) return;
+    const startedTermId = term.id;
     retranslating = true;
     retranslateError = '';
     retranslateAttempts = [];
     startRetranslateTimer();
     try {
       const { result } = await translateTerm(term.text, (a) => {
+        if (term?.id !== startedTermId) return;
         const last = retranslateAttempts[retranslateAttempts.length - 1];
         if (last && last.model === a.model && last.status === 'trying') {
           retranslateAttempts = [...retranslateAttempts.slice(0, -1), a];
@@ -333,6 +361,8 @@
           retranslateAttempts = [...retranslateAttempts, a];
         }
       });
+
+      if (term?.id !== startedTermId) return;
 
       // Enter edit mode and pre-fill senses with the fresh translation
       enterEditMode();
@@ -386,11 +416,15 @@
         }
       }
     } catch (e: unknown) {
-      retranslateError = e instanceof Error ? e.message : String(e);
+      if (term?.id === startedTermId) {
+        retranslateError = e instanceof Error ? e.message : String(e);
+      }
     } finally {
-      retranslateFinalElapsed = retranslateElapsed;
-      retranslating = false;
-      stopRetranslateTimer();
+      if (term?.id === startedTermId) {
+        retranslateFinalElapsed = retranslateElapsed;
+        retranslating = false;
+        stopRetranslateTimer();
+      }
     }
   }
 


### PR DESCRIPTION
- Strip markdown code fences (```json … ```) before JSON.parse so Claude
  Haiku no longer fails with "Invalid JSON" and the paid-tier fallback
  actually runs when free-tier models time out.
- Auto-scroll the n-gram slider while dragging near its edges and scroll
  the active endpoint into view on keyboard moves, so off-screen words
  on small screens become reachable.
- Reset audit/retranslate status (attempts, elapsed, errors, timers) when
  switching to another term and guard in-flight calls with the term id at
  start so a late callback can't write to the new term.