### PR TITLE
Fix race condition in quiz initialization with mastery store

### DIFF
--- a/src/lib/stores/mastery.ts
+++ b/src/lib/stores/mastery.ts
@@ -6,6 +6,8 @@ import { supabase } from '$lib/supabase';
 import { authUser } from '$lib/stores/auth';
 
 export const progressMap = writable<Map<string, LocalProgress>>(new Map());
+/** True once loadMastery() has finished populating progressMap for the current user. */
+export const masteryReady = writable(false);
 
 export function progressKey(itemType: 'term' | 'question', itemId: string): string {
   return `${itemType}:${itemId}`;
@@ -23,10 +25,12 @@ export async function loadMastery(userId: string): Promise<void> {
   const all = await db.progressV2.where('userId').equals(userId).toArray();
   const map = new Map(all.map((p) => [progressKey(p.itemType, p.itemId), p]));
   progressMap.set(map);
+  masteryReady.set(true);
 }
 
 export function clearMastery(): void {
   progressMap.set(new Map());
+  masteryReady.set(false);
 }
 
 export async function saveProgress(progress: ProgressInput): Promise<void> {

--- a/src/routes/quiz/+page.svelte
+++ b/src/routes/quiz/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
   import { db } from '$lib/db';
-  import { progressMap, getProgress, saveProgress } from '$lib/stores/mastery';
+  import { progressMap, masteryReady, getProgress, saveProgress } from '$lib/stores/mastery';
   import { improveProgress, canPractice, shuffleByIndex, getBadge } from '$lib/srs';
   import { sessionLookups } from '$lib/stores/session';
   import { authUser } from '$lib/stores/auth';
@@ -15,6 +16,9 @@
 
   let allQuestions: Question[] = [];
   let examFilter: ExamFilter = 'all';
+  // Guards to avoid double-init when both onMount and $masteryReady fire
+  let questionsLoaded = false;
+  let sessionInit = false;
 
   // Session snapshot — linear flow, not an infinite loop
   let sessionQuestions: Question[] = [];
@@ -71,13 +75,29 @@
 
   $: if (currentQ) loadQuestion(currentQ);
 
+  // Start session only after BOTH questions are loaded AND progressMap is ready.
+  // On a fresh page load the layout's loadMastery() (which involves network
+  // sync) finishes AFTER this onMount, so we must wait for masteryReady.
+  // On subsequent in-app navigations masteryReady is already true, so we init
+  // immediately inside onMount.
   onMount(async () => {
     [allQuestions, allTermsForTokenize] = await Promise.all([
       db.questions.toArray(),
       db.terms.toArray(),
     ]);
-    initSession();
+    questionsLoaded = true;
+    if (get(masteryReady)) {
+      sessionInit = true;
+      initSession();
+    }
+    // Otherwise the $masteryReady reactive block below will fire once mastery loads.
   });
+
+  // Fires when the layout's loadMastery() completes (may be after onMount).
+  $: if ($masteryReady && questionsLoaded && !sessionInit) {
+    sessionInit = true;
+    initSession();
+  }
 
   function buildPool(filter: ExamFilter): Question[] {
     const filtered = allQuestions.filter((q) => filter === 'all' || q.exam === filter);


### PR DESCRIPTION
## Summary
This PR fixes a race condition where the quiz session could initialize before the mastery progress data was fully loaded from the database. This was particularly problematic on fresh page loads where the layout's `loadMastery()` completes after the quiz component's `onMount`.

## Key Changes
- Added `masteryReady` store to track when mastery data has finished loading
- Introduced guard flags (`questionsLoaded` and `sessionInit`) to prevent double initialization
- Modified quiz initialization to wait for both questions to load AND mastery data to be ready before starting the session
- Added reactive block that triggers session initialization once `masteryReady` becomes true (for fresh page loads)
- Updated `loadMastery()` to set `masteryReady` to true upon completion
- Updated `clearMastery()` to reset `masteryReady` to false

## Implementation Details
The fix uses a two-pronged approach:
1. **Immediate initialization**: If `masteryReady` is already true when `onMount` fires (subsequent in-app navigations), initialize immediately
2. **Deferred initialization**: If `masteryReady` is false, wait for the reactive block to trigger once the store updates (fresh page loads with network sync)

This ensures the session always has access to the complete progress map before attempting to filter and sort questions by mastery level.

https://claude.ai/code/session_01FNdztnhxDZEj9ujq9GVs5g