### PR TITLE
Fix SRS max level items staying overdue after correct answer

### DIFF
--- a/src/lib/srs.test.ts
+++ b/src/lib/srs.test.ts
@@ -39,6 +39,25 @@ describe('improveProgress', () => {
     expect(p.level).toBe(MAX_LEVEL);
   });
 
+  it('re-schedules nextReview at MAX_LEVEL on correct answer', () => {
+    // Regression: previously the function returned base unchanged at max
+    // level, so an overdue item kept its past nextReview and reappeared in
+    // every session even after being answered correctly.
+    const pastReview = new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString();
+    const base = {
+      itemType: 'question' as const,
+      itemId: 'x',
+      level: MAX_LEVEL,
+      xp: 440,
+      nextReview: pastReview,
+    };
+    const p = improveProgress(base, 'question', 'x', false);
+    expect(p.level).toBe(MAX_LEVEL);
+    expect(p.xp).toBe(440);
+    expect(new Date(p.nextReview!).getTime()).toBeGreaterThan(Date.now());
+    expect(canPractice(p)).toBe(false);
+  });
+
   it('does not change level on wrong answer, adds incentive XP', () => {
     const base = { itemType: 'term' as const, itemId: 'x', level: 1, xp: 40, nextReview: null };
     const p = improveProgress(base, 'term', 'x', true);

--- a/src/lib/srs.ts
+++ b/src/lib/srs.ts
@@ -41,7 +41,13 @@ export function improveProgress(
     };
   }
 
-  return base;
+  // At max level: keep level/xp but still re-schedule, otherwise an overdue
+  // item would stay overdue forever (canPractice keeps returning true and the
+  // same question reappears every session).
+  return {
+    ...base,
+    nextReview: new Date(Date.now() + SRS_INTERVALS[MAX_LEVEL]).toISOString(),
+  };
 }
 
 export function getBadge(level: number): string {


### PR DESCRIPTION
## Summary
Fixed a regression where items at maximum SRS level would retain their past `nextReview` date after being answered correctly, causing them to reappear in every practice session indefinitely.

## Key Changes
- **srs.ts**: Modified `improveProgress()` to re-schedule `nextReview` even when an item is already at `MAX_LEVEL`. Previously, the function returned the base object unchanged at max level, which meant overdue items would never be rescheduled and `canPractice()` would continue returning `true`.
- **srs.test.ts**: Added regression test case that verifies items at `MAX_LEVEL` get their `nextReview` rescheduled to a future date after a correct answer, and that `canPractice()` returns `false` for the rescheduled item.

## Implementation Details
- When an item reaches `MAX_LEVEL`, it now receives a new `nextReview` timestamp calculated using `SRS_INTERVALS[MAX_LEVEL]` instead of keeping its old (potentially past) date.
- This ensures that even max-level items follow the normal SRS scheduling flow and don't get stuck in an "always available to practice" state.

https://claude.ai/code/session_01LeKAQVwauWumgsduyVMSk4