### PR TITLE
Use PostgREST error code for migration 003 compatibility checks

### DIFF
--- a/src/lib/translate.ts
+++ b/src/lib/translate.ts
@@ -209,11 +209,12 @@ export async function lookupOrTranslate(
   };
 
   // Backward compatibility: some deployments may not have run migration 003 (note column).
+  // PGRST204 = "Column not found in schema cache" — stable PostgREST error code.
   let { error: senseError } = await supabase.from('term_senses').insert({
     ...sensePayloadBase,
     note: result.note || null,
   });
-  if (senseError?.message?.includes("'note' column")) {
+  if (senseError?.code === 'PGRST204' || senseError?.message?.includes("'note' column")) {
     ({ error: senseError } = await supabase.from('term_senses').insert(sensePayloadBase));
   }
   if (senseError) throw new Error(`Không lưu được nghĩa: ${senseError.message}`);
@@ -246,7 +247,7 @@ export async function lookupOrTranslate(
       ...scrumPayload,
       note: null,
     });
-    if (scrumErr?.message?.includes("'note' column")) {
+    if (scrumErr?.code === 'PGRST204' || scrumErr?.message?.includes("'note' column")) {
       ({ error: scrumErr } = await supabase.from('term_senses').insert(scrumPayload));
     }
     // Scrum sense failure is non-fatal — general sense already saved.
@@ -300,7 +301,7 @@ async function enrichScrumSense(
     ...scrumPayload,
     note: null,
   });
-  if (scrumErr?.message?.includes("'note' column")) {
+  if (scrumErr?.code === 'PGRST204' || scrumErr?.message?.includes("'note' column")) {
     ({ error: scrumErr } = await supabase.from('term_senses').insert(scrumPayload));
   }
 


### PR DESCRIPTION
## Summary
Improved error handling for backward compatibility with deployments that haven't run migration 003 by using the stable PostgREST error code `PGRST204` instead of relying solely on error message string matching.

## Changes
- Updated three error checks in `src/lib/translate.ts` to use `senseError?.code === 'PGRST204'` as the primary condition for detecting missing 'note' column errors
- Maintained the existing message-based fallback check for additional robustness
- Added clarifying comment explaining that `PGRST204` is the stable PostgREST error code for "Column not found in schema cache"

## Implementation Details
The changes affect error handling in three locations:
1. `lookupOrTranslate()` - term_senses insert with note field (line 216)
2. `lookupOrTranslate()` - scrum sense insert with note field (line 250)
3. `enrichScrumSense()` - scrum sense insert with note field (line 304)

Each location now checks for the error code first, then falls back to message matching, making the code more reliable and maintainable across different PostgREST versions.

https://claude.ai/code/session_01Y2yh8JDZYuMSYntfbGGhzs