### PR TITLE
Refactor ngram slider from horizontal to vertical layout

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1249,14 +1249,14 @@ progress::-webkit-progress-value {
 /* Slider — drag to pick a phrase */
 .ngram-slider {
   display: flex;
-  align-items: stretch;
+  flex-wrap: wrap;
+  align-items: flex-start;
   gap: 0;
   padding: 0.5rem 0.25rem 0.75rem;
-  overflow-x: auto;
+  overflow-y: auto;
+  max-height: 200px;
   position: relative;
-  /* Container allows horizontal panning for long sentences; individual notches
-     opt out so drag-select wins over scroll when the user starts on a notch. */
-  touch-action: pan-x;
+  touch-action: none;
   user-select: none;
   -webkit-user-select: none;
   background: var(--bg);
@@ -1327,10 +1327,10 @@ progress::-webkit-progress-value {
 }
 
 .ngram-divider {
-  flex: 0 0 auto;
-  width: 1px;
+  flex-basis: 100%;
+  height: 1px;
   background: var(--border);
-  margin: 0.4rem 0.35rem;
+  margin: 0.35rem 0.25rem;
 }
 
 .ngram-preview {

--- a/src/lib/components/NgramPopup.svelte
+++ b/src/lib/components/NgramPopup.svelte
@@ -211,7 +211,7 @@
     phase = 'list';
   }
 
-  function notchIndexFromX(clientX: number): number | null {
+  function notchIndexFromPoint(clientX: number, clientY: number): number | null {
     if (!sliderEl) return null;
     const notches = sliderEl.querySelectorAll<HTMLElement>('.ngram-notch');
     let bestIdx = -1;
@@ -221,7 +221,8 @@
       if (idx < 0 || words[idx]?.segment !== initialSegment) continue;
       const r = notches[i].getBoundingClientRect();
       const cx = r.left + r.width / 2;
-      const dist = Math.abs(clientX - cx);
+      const cy = r.top + r.height / 2;
+      const dist = Math.hypot(clientX - cx, clientY - cy);
       if (dist < bestDist) {
         bestDist = dist;
         bestIdx = idx;
@@ -231,7 +232,7 @@
   }
 
   function onPointerDown(e: PointerEvent) {
-    const idx = notchIndexFromX(e.clientX);
+    const idx = notchIndexFromPoint(e.clientX, e.clientY);
     if (idx === null) return;
     e.preventDefault();
     dragOrigin = idx;
@@ -245,18 +246,17 @@
 
   function onPointerMove(e: PointerEvent) {
     if (dragOrigin === null) return;
-    // Auto-scroll when the user drags near the slider edges so off-screen
-    // notches on small screens become reachable while pointer is captured.
+    // Auto-scroll vertically when dragging near top/bottom of the slider.
     if (sliderEl) {
       const rect = sliderEl.getBoundingClientRect();
       const edge = 40;
-      if (e.clientX < rect.left + edge) {
-        sliderEl.scrollLeft -= Math.max(6, (rect.left + edge - e.clientX) / 3);
-      } else if (e.clientX > rect.right - edge) {
-        sliderEl.scrollLeft += Math.max(6, (e.clientX - (rect.right - edge)) / 3);
+      if (e.clientY < rect.top + edge) {
+        sliderEl.scrollTop -= Math.max(6, (rect.top + edge - e.clientY) / 3);
+      } else if (e.clientY > rect.bottom - edge) {
+        sliderEl.scrollTop += Math.max(6, (e.clientY - (rect.bottom - edge)) / 3);
       }
     }
-    const idx = notchIndexFromX(e.clientX);
+    const idx = notchIndexFromPoint(e.clientX, e.clientY);
     if (idx === null) return;
     leftIdx = Math.min(dragOrigin, idx);
     rightIdx = Math.max(dragOrigin, idx);
@@ -473,8 +473,7 @@
   {:else}
     <h3 style="margin:0 0 0.25rem;font-size:1rem">Kéo để chọn cụm</h3>
     <p class="text-secondary" style="font-size:0.78rem;margin-bottom:0.6rem">
-      Mỗi từ là một điểm; không vượt qua dấu câu. Bàn phím: ←/→ chỉnh đầu phải, Shift+←/→ chỉnh đầu
-      trái, Enter để dịch.
+      Kéo để chọn cụm từ — không thể chọn qua dấu câu.
     </p>
 
     <div


### PR DESCRIPTION
## Summary
This PR refactors the ngram phrase selection slider from a horizontal scrolling layout to a vertical wrapping layout, improving usability on small screens and simplifying the interaction model.

## Key Changes

- **Layout transformation**: Changed `.ngram-slider` from horizontal scrolling (`overflow-x: auto`) to vertical scrolling (`overflow-y: auto`) with `flex-wrap: wrap` and `max-height: 200px`
- **Distance calculation**: Updated `notchIndexFromX()` to `notchIndexFromPoint()` to use 2D Euclidean distance (`Math.hypot`) instead of 1D horizontal distance, enabling more intuitive selection in the new vertical layout
- **Auto-scroll logic**: Reversed auto-scroll behavior from horizontal (left/right edges) to vertical (top/bottom edges) when dragging near slider boundaries
- **Divider styling**: Changed `.ngram-divider` from vertical (1px width) to horizontal (1px height) to match the new layout orientation
- **Touch interaction**: Changed `touch-action` from `pan-x` to `none` to prevent unintended scrolling during drag-select operations
- **UI text**: Simplified Vietnamese instructions to focus on the core drag-to-select functionality and punctuation boundary constraints

## Implementation Details

The refactoring maintains the same drag-select interaction pattern while adapting it to a vertical layout. The 2D distance calculation now properly accounts for both horizontal and vertical proximity when determining which notch the user is closest to, making selection more forgiving in the new layout.

https://claude.ai/code/session_01PLgKkY49tBumEJSKLeFC5C