### PR TITLE
feat(books): xoá emoji thừa ở header, xoá sách Go, ghi nhớ vị trí đọc

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -84,8 +84,8 @@
   $: currentPath = $page.url.pathname;
 
   const navLinks = [
-    { href: `${base}/books`, label: '📖 Sách' },
-    { href: `${base}/vocab`, label: '📚 Từ đã tra' },
+    { href: `${base}/books`, label: 'Sách' },
+    { href: `${base}/vocab`, label: 'Từ đã tra' },
     { href: `${base}/quiz`, label: 'Kiểm tra' },
   ];
 </script>
@@ -93,7 +93,7 @@
 <div class="app-container">
   <!-- Nav -->
   <nav class="navbar">
-    <a href="{base}/" class="navbar-brand">KfR 📚</a>
+    <a href="{base}/" class="navbar-brand">KfR</a>
     <div class="navbar-links">
       {#each navLinks as link}
         <a href={link.href} class:active={currentPath === link.href || currentPath.startsWith(link.href + '/')}>{link.label}</a>
@@ -138,7 +138,7 @@
       <div class="auth-wall">
         <h2>KfR — Scrum Learning</h2>
         <p class="text-secondary">Học tiếng Anh chuyên ngành Scrum · Luyện thi PSM I &amp; PSPO I</p>
-        <button class="btn btn-primary" on:click={signIn}>🔑 Đăng nhập với Google</button>
+        <button class="btn btn-primary" on:click={signIn}>Đăng nhập với Google</button>
         <p class="text-secondary" style="font-size:0.8rem">Chỉ tài khoản được uỷ quyền mới truy cập được nội dung.</p>
       </div>
     {:else}

--- a/src/routes/books/+page.svelte
+++ b/src/routes/books/+page.svelte
@@ -44,6 +44,23 @@
   let loadPhase: 'idle' | 'loading' | 'done' = 'idle';
   let showToc = false;         // EPUB: sidebar chapter list
 
+  // ── Reading position persistence ─────────────────────────────────────────
+  const STORAGE_KEY = 'kfr:book-reader';
+
+  function saveReadingState() {
+    if (!selectedBook) return;
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ bookId: selectedBook.id, sectionIdx: currentIdx }));
+    } catch {}
+  }
+
+  function loadReadingState(): { bookId: string; sectionIdx: number } | null {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : null;
+    } catch { return null; }
+  }
+
   // ── Translate (identical to quiz) ────────────────────────────────────────
   let allTerms: Term[] = [];
   let selectedTermId: string | null = null;
@@ -66,6 +83,13 @@
       const res = await fetch(`${base}/books/catalog.json`);
       if (res.ok) catalog = await res.json();
     } catch { /* catalog optional */ }
+
+    // Restore last reading state
+    const saved = loadReadingState();
+    if (saved && catalog.length > 0) {
+      const lastBook = catalog.find((b) => b.id === saved.bookId && b.file);
+      if (lastBook) await openBook(lastBook);
+    }
   });
 
   // ── Open book ─────────────────────────────────────────────────────────────
@@ -74,6 +98,10 @@
       if (book.externalUrl) window.open(book.externalUrl, '_blank', 'noopener');
       return;
     }
+    // Restore saved position for this book, if any
+    const saved = loadReadingState();
+    const restoreIdx = saved?.bookId === book.id ? saved.sectionIdx : 0;
+
     selectedBook = book;
     sections = [];
     totalSections = 0;
@@ -99,6 +127,8 @@
         totalSections = meta.totalPages;
       }
       loadPhase = 'done';
+      currentIdx = Math.max(0, Math.min(restoreIdx, sections.length - 1));
+      saveReadingState();
     } catch (err) {
       loadError = err instanceof Error ? err.message : String(err);
       loadPhase = 'idle';
@@ -107,9 +137,9 @@
     allTerms = await db.terms.toArray();
   }
 
-  function prev() { if (currentIdx > 0) { currentIdx--; showToc = false; } }
-  function next() { if (currentIdx < sections.length - 1) { currentIdx++; showToc = false; } }
-  function goTo(i: number) { currentIdx = Math.max(0, Math.min(i, sections.length - 1)); showToc = false; }
+  function prev() { if (currentIdx > 0) { currentIdx--; showToc = false; saveReadingState(); } }
+  function next() { if (currentIdx < sections.length - 1) { currentIdx++; showToc = false; saveReadingState(); } }
+  function goTo(i: number) { currentIdx = Math.max(0, Math.min(i, sections.length - 1)); showToc = false; saveReadingState(); }
 
   // ── Tap-to-gloss (mirrors quiz) ───────────────────────────────────────────
   function handleTextInteraction(e: MouseEvent | KeyboardEvent) {
@@ -159,7 +189,7 @@
 <!-- ── SHELF ──────────────────────────────────────────────────────────────── -->
 {#if !selectedBook}
   <div class="books-shelf-header">
-    <h2 class="books-shelf-title">📖 Thư viện tài liệu</h2>
+    <h2 class="books-shelf-title">Thư viện tài liệu</h2>
     <p class="text-secondary" style="font-size:0.88rem;margin:0">
       Click từ bất kỳ để tra nghĩa — giống hệt chức năng trong Quiz.
     </p>
@@ -232,8 +262,13 @@
 
   <!-- Error -->
   {#if loadError}
-    <div class="card" style="border-color:var(--danger);padding:1rem">
-      <p style="color:var(--danger);margin:0">⚠️ Không tải được: {loadError}</p>
+    <div class="card" style="border-color:var(--danger);padding:1rem;display:flex;flex-direction:column;gap:0.5rem">
+      <p style="color:var(--danger);margin:0">Không tải được: {loadError}</p>
+      {#if selectedBook?.sourceUrl}
+        <a href={selectedBook.sourceUrl} target="_blank" rel="noopener" style="font-size:0.85rem;color:var(--primary,#a78bfa)">
+          Mở trang gốc: {selectedBook.sourceUrl}
+        </a>
+      {/if}
     </div>
   {/if}
 

--- a/static/books/catalog.json
+++ b/static/books/catalog.json
@@ -9,14 +9,5 @@
     "sourceUrl": "https://scrumguides.org/",
     "tags": ["scrum", "psm", "pspo", "official"],
     "description": "Tài liệu chính thức định nghĩa Scrum Framework (bản US, tháng 11/2020). Phát hành dưới giấy phép Creative Commons BY-SA 4.0."
-  },
-  {
-    "id": "go-with-domain",
-    "title": "Building Modern Business Software in Go",
-    "author": "Robert Laszczak & Miłosz Smółka",
-    "year": 2023,
-    "externalUrl": "https://threedots.tech/go-with-the-domain/",
-    "tags": ["go", "ddd", "software-engineering"],
-    "description": "Domain-Driven Design và Clean Architecture trong Go — Three Dots Labs. Tải miễn phí từ trang chính thức của tác giả."
   }
 ]


### PR DESCRIPTION
- Xoá emoji khỏi navbar (KfR, Sách, Từ đã tra, nút Đăng nhập)
- Xoá sách "Building Modern Business Software in Go" khỏi catalog
- Thêm localStorage lưu sách đang mở và trang/section đang đọc;
  tự động khôi phục khi quay lại trang /books
- Khi PDF lỗi, hiển thị link đến sourceUrl để người dùng truy cập
  tài liệu từ trang gốc

https://claude.ai/code/session_01Mw9f1mdTeVYuDkHcyLDTP9