### PR TITLE
Show only highest badge in quiz-progress-meta

### DIFF
--- a/src/lib/srs.test.ts
+++ b/src/lib/srs.test.ts
@@ -114,8 +114,8 @@ describe('getBadge', () => {
     expect(getBadge(0)).toBe('🥉');
   });
 
-  it('returns cumulative badges', () => {
-    expect(getBadge(2)).toBe('🥉🥈🥇');
+  it('returns only the highest badge', () => {
+    expect(getBadge(2)).toBe('🥇');
   });
 });
 

--- a/src/lib/srs.ts
+++ b/src/lib/srs.ts
@@ -52,7 +52,7 @@ export function improveProgress(
 
 export function getBadge(level: number): string {
   if (level < 0) return '';
-  return BADGES.slice(0, level + 1).join('');
+  return BADGES[level] ?? '';
 }
 
 export function getTotalXP(progresses: ProgressInput[]): number {


### PR DESCRIPTION
getBadge now returns the single badge at the current level instead of
concatenating all badges from level 0 up, so only the highest-value
badge is displayed.

https://claude.ai/code/session_01UzMd7dRouUQeCWXCP9Cdyh